### PR TITLE
Introduce RepeatedFieldBuilderV3Internal and SingleFieldBuilderV3Internal

### DIFF
--- a/protobuf-api/src/main/java/com/google/protobuf/Api.java
+++ b/protobuf-api/src/main/java/com/google/protobuf/Api.java
@@ -1186,8 +1186,8 @@ private static final long serialVersionUID = 0L;
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Method, com.google.protobuf.Method.Builder, com.google.protobuf.MethodOrBuilder> methodsBuilder_;
+    private RepeatedFieldBuilderV3Internal<
+            Method, Method.Builder, MethodOrBuilder> methodsBuilder_;
 
     /**
      * <pre>
@@ -1474,12 +1474,12 @@ private static final long serialVersionUID = 0L;
          getMethodsBuilderList() {
       return getMethodsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Method, com.google.protobuf.Method.Builder, com.google.protobuf.MethodOrBuilder> 
+    private RepeatedFieldBuilderV3Internal<
+            Method, Method.Builder, MethodOrBuilder>
         getMethodsFieldBuilder() {
       if (methodsBuilder_ == null) {
-        methodsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.protobuf.Method, com.google.protobuf.Method.Builder, com.google.protobuf.MethodOrBuilder>(
+        methodsBuilder_ = new RepeatedFieldBuilderV3Internal<
+                    Method, Method.Builder, MethodOrBuilder>(
                 methods_,
                 ((bitField0_ & 0x00000002) != 0),
                 getParentForChildren(),
@@ -1498,8 +1498,8 @@ private static final long serialVersionUID = 0L;
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> optionsBuilder_;
+    private RepeatedFieldBuilderV3Internal<
+            Option, Option.Builder, OptionOrBuilder> optionsBuilder_;
 
     /**
      * <pre>
@@ -1786,12 +1786,12 @@ private static final long serialVersionUID = 0L;
          getOptionsBuilderList() {
       return getOptionsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> 
+    private RepeatedFieldBuilderV3Internal<
+            Option, Option.Builder, OptionOrBuilder>
         getOptionsFieldBuilder() {
       if (optionsBuilder_ == null) {
-        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder>(
+        optionsBuilder_ = new RepeatedFieldBuilderV3Internal<
+                    Option, Option.Builder, OptionOrBuilder>(
                 options_,
                 ((bitField0_ & 0x00000004) != 0),
                 getParentForChildren(),
@@ -1984,8 +1984,8 @@ private static final long serialVersionUID = 0L;
     }
 
     private com.google.protobuf.SourceContext sourceContext_;
-    private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder> sourceContextBuilder_;
+    private SingleFieldBuilderV3Internal<
+            SourceContext, SourceContext.Builder, SourceContextOrBuilder> sourceContextBuilder_;
     /**
      * <pre>
      * Source context for the protocol buffer service represented by this
@@ -2135,12 +2135,12 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.google.protobuf.SourceContext source_context = 5;</code>
      */
-    private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder> 
+    private SingleFieldBuilderV3Internal<
+            SourceContext, SourceContext.Builder, SourceContextOrBuilder>
         getSourceContextFieldBuilder() {
       if (sourceContextBuilder_ == null) {
-        sourceContextBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder>(
+        sourceContextBuilder_ = new SingleFieldBuilderV3Internal<
+                    SourceContext, SourceContext.Builder, SourceContextOrBuilder>(
                 getSourceContext(),
                 getParentForChildren(),
                 isClean());
@@ -2158,8 +2158,8 @@ private static final long serialVersionUID = 0L;
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Mixin, com.google.protobuf.Mixin.Builder, com.google.protobuf.MixinOrBuilder> mixinsBuilder_;
+    private RepeatedFieldBuilderV3Internal<
+            Mixin, Mixin.Builder, MixinOrBuilder> mixinsBuilder_;
 
     /**
      * <pre>
@@ -2446,12 +2446,12 @@ private static final long serialVersionUID = 0L;
          getMixinsBuilderList() {
       return getMixinsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Mixin, com.google.protobuf.Mixin.Builder, com.google.protobuf.MixinOrBuilder> 
+    private RepeatedFieldBuilderV3Internal<
+            Mixin, Mixin.Builder, MixinOrBuilder>
         getMixinsFieldBuilder() {
       if (mixinsBuilder_ == null) {
-        mixinsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.protobuf.Mixin, com.google.protobuf.Mixin.Builder, com.google.protobuf.MixinOrBuilder>(
+        mixinsBuilder_ = new RepeatedFieldBuilderV3Internal<
+                    Mixin, Mixin.Builder, MixinOrBuilder>(
                 mixins_,
                 ((bitField0_ & 0x00000020) != 0),
                 getParentForChildren(),

--- a/protobuf-api/src/main/java/com/google/protobuf/DescriptorProtos.java
+++ b/protobuf-api/src/main/java/com/google/protobuf/DescriptorProtos.java
@@ -826,8 +826,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FileDescriptorProto, com.google.protobuf.DescriptorProtos.FileDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FileDescriptorProtoOrBuilder> fileBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                FileDescriptorProto, FileDescriptorProto.Builder, FileDescriptorProtoOrBuilder> fileBuilder_;
 
       /**
        * <code>repeated .google.protobuf.FileDescriptorProto file = 1;</code>
@@ -1042,12 +1042,12 @@ public final class DescriptorProtos {
            getFileBuilderList() {
         return getFileFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FileDescriptorProto, com.google.protobuf.DescriptorProtos.FileDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FileDescriptorProtoOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                FileDescriptorProto, FileDescriptorProto.Builder, FileDescriptorProtoOrBuilder>
           getFileFieldBuilder() {
         if (fileBuilder_ == null) {
-          fileBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FileDescriptorProto, com.google.protobuf.DescriptorProtos.FileDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FileDescriptorProtoOrBuilder>(
+          fileBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        FileDescriptorProto, FileDescriptorProto.Builder, FileDescriptorProtoOrBuilder>(
                   file_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -3796,8 +3796,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.DescriptorProto, com.google.protobuf.DescriptorProtos.DescriptorProto.Builder, com.google.protobuf.DescriptorProtos.DescriptorProtoOrBuilder> messageTypeBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                DescriptorProto, DescriptorProto.Builder, DescriptorProtoOrBuilder> messageTypeBuilder_;
 
       /**
        * <pre>
@@ -4084,12 +4084,12 @@ public final class DescriptorProtos {
            getMessageTypeBuilderList() {
         return getMessageTypeFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.DescriptorProto, com.google.protobuf.DescriptorProtos.DescriptorProto.Builder, com.google.protobuf.DescriptorProtos.DescriptorProtoOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                DescriptorProto, DescriptorProto.Builder, DescriptorProtoOrBuilder>
           getMessageTypeFieldBuilder() {
         if (messageTypeBuilder_ == null) {
-          messageTypeBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.DescriptorProto, com.google.protobuf.DescriptorProtos.DescriptorProto.Builder, com.google.protobuf.DescriptorProtos.DescriptorProtoOrBuilder>(
+          messageTypeBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        DescriptorProto, DescriptorProto.Builder, DescriptorProtoOrBuilder>(
                   messageType_,
                   ((bitField0_ & 0x00000020) != 0),
                   getParentForChildren(),
@@ -4108,8 +4108,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.EnumDescriptorProto, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProtoOrBuilder> enumTypeBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                EnumDescriptorProto, EnumDescriptorProto.Builder, EnumDescriptorProtoOrBuilder> enumTypeBuilder_;
 
       /**
        * <code>repeated .google.protobuf.EnumDescriptorProto enum_type = 5;</code>
@@ -4324,12 +4324,12 @@ public final class DescriptorProtos {
            getEnumTypeBuilderList() {
         return getEnumTypeFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.EnumDescriptorProto, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProtoOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                EnumDescriptorProto, EnumDescriptorProto.Builder, EnumDescriptorProtoOrBuilder>
           getEnumTypeFieldBuilder() {
         if (enumTypeBuilder_ == null) {
-          enumTypeBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.EnumDescriptorProto, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProtoOrBuilder>(
+          enumTypeBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        EnumDescriptorProto, EnumDescriptorProto.Builder, EnumDescriptorProtoOrBuilder>(
                   enumType_,
                   ((bitField0_ & 0x00000040) != 0),
                   getParentForChildren(),
@@ -4348,8 +4348,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.ServiceDescriptorProto, com.google.protobuf.DescriptorProtos.ServiceDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.ServiceDescriptorProtoOrBuilder> serviceBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                ServiceDescriptorProto, ServiceDescriptorProto.Builder, ServiceDescriptorProtoOrBuilder> serviceBuilder_;
 
       /**
        * <code>repeated .google.protobuf.ServiceDescriptorProto service = 6;</code>
@@ -4564,12 +4564,12 @@ public final class DescriptorProtos {
            getServiceBuilderList() {
         return getServiceFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.ServiceDescriptorProto, com.google.protobuf.DescriptorProtos.ServiceDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.ServiceDescriptorProtoOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                ServiceDescriptorProto, ServiceDescriptorProto.Builder, ServiceDescriptorProtoOrBuilder>
           getServiceFieldBuilder() {
         if (serviceBuilder_ == null) {
-          serviceBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.ServiceDescriptorProto, com.google.protobuf.DescriptorProtos.ServiceDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.ServiceDescriptorProtoOrBuilder>(
+          serviceBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        ServiceDescriptorProto, ServiceDescriptorProto.Builder, ServiceDescriptorProtoOrBuilder>(
                   service_,
                   ((bitField0_ & 0x00000080) != 0),
                   getParentForChildren(),
@@ -4588,8 +4588,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder> extensionBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                FieldDescriptorProto, FieldDescriptorProto.Builder, FieldDescriptorProtoOrBuilder> extensionBuilder_;
 
       /**
        * <code>repeated .google.protobuf.FieldDescriptorProto extension = 7;</code>
@@ -4804,12 +4804,12 @@ public final class DescriptorProtos {
            getExtensionBuilderList() {
         return getExtensionFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                FieldDescriptorProto, FieldDescriptorProto.Builder, FieldDescriptorProtoOrBuilder>
           getExtensionFieldBuilder() {
         if (extensionBuilder_ == null) {
-          extensionBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder>(
+          extensionBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        FieldDescriptorProto, FieldDescriptorProto.Builder, FieldDescriptorProtoOrBuilder>(
                   extension_,
                   ((bitField0_ & 0x00000100) != 0),
                   getParentForChildren(),
@@ -4820,8 +4820,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.FileOptions options_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FileOptions, com.google.protobuf.DescriptorProtos.FileOptions.Builder, com.google.protobuf.DescriptorProtos.FileOptionsOrBuilder> optionsBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FileOptions, FileOptions.Builder, FileOptionsOrBuilder> optionsBuilder_;
       /**
        * <code>optional .google.protobuf.FileOptions options = 8;</code>
        * @return Whether the options field is set.
@@ -4926,12 +4926,12 @@ public final class DescriptorProtos {
       /**
        * <code>optional .google.protobuf.FileOptions options = 8;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FileOptions, com.google.protobuf.DescriptorProtos.FileOptions.Builder, com.google.protobuf.DescriptorProtos.FileOptionsOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FileOptions, FileOptions.Builder, FileOptionsOrBuilder>
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FileOptions, com.google.protobuf.DescriptorProtos.FileOptions.Builder, com.google.protobuf.DescriptorProtos.FileOptionsOrBuilder>(
+          optionsBuilder_ = new SingleFieldBuilderV3Internal<
+                        FileOptions, FileOptions.Builder, FileOptionsOrBuilder>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -4941,8 +4941,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.SourceCodeInfo sourceCodeInfo_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.SourceCodeInfo, com.google.protobuf.DescriptorProtos.SourceCodeInfo.Builder, com.google.protobuf.DescriptorProtos.SourceCodeInfoOrBuilder> sourceCodeInfoBuilder_;
+      private SingleFieldBuilderV3Internal<
+                SourceCodeInfo, SourceCodeInfo.Builder, SourceCodeInfoOrBuilder> sourceCodeInfoBuilder_;
       /**
        * <pre>
        * This field contains optional information about the original source code.
@@ -5110,12 +5110,12 @@ public final class DescriptorProtos {
        *
        * <code>optional .google.protobuf.SourceCodeInfo source_code_info = 9;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.SourceCodeInfo, com.google.protobuf.DescriptorProtos.SourceCodeInfo.Builder, com.google.protobuf.DescriptorProtos.SourceCodeInfoOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                SourceCodeInfo, SourceCodeInfo.Builder, SourceCodeInfoOrBuilder>
           getSourceCodeInfoFieldBuilder() {
         if (sourceCodeInfoBuilder_ == null) {
-          sourceCodeInfoBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.SourceCodeInfo, com.google.protobuf.DescriptorProtos.SourceCodeInfo.Builder, com.google.protobuf.DescriptorProtos.SourceCodeInfoOrBuilder>(
+          sourceCodeInfoBuilder_ = new SingleFieldBuilderV3Internal<
+                        SourceCodeInfo, SourceCodeInfo.Builder, SourceCodeInfoOrBuilder>(
                   getSourceCodeInfo(),
                   getParentForChildren(),
                   isClean());
@@ -6397,8 +6397,8 @@ public final class DescriptorProtos {
         }
 
         private com.google.protobuf.DescriptorProtos.ExtensionRangeOptions options_;
-        private com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.DescriptorProtos.ExtensionRangeOptions, com.google.protobuf.DescriptorProtos.ExtensionRangeOptions.Builder, com.google.protobuf.DescriptorProtos.ExtensionRangeOptionsOrBuilder> optionsBuilder_;
+        private SingleFieldBuilderV3Internal<
+                    ExtensionRangeOptions, ExtensionRangeOptions.Builder, ExtensionRangeOptionsOrBuilder> optionsBuilder_;
         /**
          * <code>optional .google.protobuf.ExtensionRangeOptions options = 3;</code>
          * @return Whether the options field is set.
@@ -6503,12 +6503,12 @@ public final class DescriptorProtos {
         /**
          * <code>optional .google.protobuf.ExtensionRangeOptions options = 3;</code>
          */
-        private com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.DescriptorProtos.ExtensionRangeOptions, com.google.protobuf.DescriptorProtos.ExtensionRangeOptions.Builder, com.google.protobuf.DescriptorProtos.ExtensionRangeOptionsOrBuilder> 
+        private SingleFieldBuilderV3Internal<
+                    ExtensionRangeOptions, ExtensionRangeOptions.Builder, ExtensionRangeOptionsOrBuilder>
             getOptionsFieldBuilder() {
           if (optionsBuilder_ == null) {
-            optionsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DescriptorProtos.ExtensionRangeOptions, com.google.protobuf.DescriptorProtos.ExtensionRangeOptions.Builder, com.google.protobuf.DescriptorProtos.ExtensionRangeOptionsOrBuilder>(
+            optionsBuilder_ = new SingleFieldBuilderV3Internal<
+                            ExtensionRangeOptions, ExtensionRangeOptions.Builder, ExtensionRangeOptionsOrBuilder>(
                     getOptions(),
                     getParentForChildren(),
                     isClean());
@@ -8754,8 +8754,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder> fieldBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                FieldDescriptorProto, FieldDescriptorProto.Builder, FieldDescriptorProtoOrBuilder> fieldBuilder_;
 
       /**
        * <code>repeated .google.protobuf.FieldDescriptorProto field = 2;</code>
@@ -8970,12 +8970,12 @@ public final class DescriptorProtos {
            getFieldBuilderList() {
         return getFieldFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                FieldDescriptorProto, FieldDescriptorProto.Builder, FieldDescriptorProtoOrBuilder>
           getFieldFieldBuilder() {
         if (fieldBuilder_ == null) {
-          fieldBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder>(
+          fieldBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        FieldDescriptorProto, FieldDescriptorProto.Builder, FieldDescriptorProtoOrBuilder>(
                   field_,
                   ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
@@ -8994,8 +8994,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder> extensionBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                FieldDescriptorProto, FieldDescriptorProto.Builder, FieldDescriptorProtoOrBuilder> extensionBuilder_;
 
       /**
        * <code>repeated .google.protobuf.FieldDescriptorProto extension = 6;</code>
@@ -9210,12 +9210,12 @@ public final class DescriptorProtos {
            getExtensionBuilderList() {
         return getExtensionFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                FieldDescriptorProto, FieldDescriptorProto.Builder, FieldDescriptorProtoOrBuilder>
           getExtensionFieldBuilder() {
         if (extensionBuilder_ == null) {
-          extensionBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FieldDescriptorProto, com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FieldDescriptorProtoOrBuilder>(
+          extensionBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        FieldDescriptorProto, FieldDescriptorProto.Builder, FieldDescriptorProtoOrBuilder>(
                   extension_,
                   ((bitField0_ & 0x00000004) != 0),
                   getParentForChildren(),
@@ -9234,8 +9234,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.DescriptorProto, com.google.protobuf.DescriptorProtos.DescriptorProto.Builder, com.google.protobuf.DescriptorProtos.DescriptorProtoOrBuilder> nestedTypeBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                DescriptorProto, Builder, DescriptorProtoOrBuilder> nestedTypeBuilder_;
 
       /**
        * <code>repeated .google.protobuf.DescriptorProto nested_type = 3;</code>
@@ -9450,12 +9450,12 @@ public final class DescriptorProtos {
            getNestedTypeBuilderList() {
         return getNestedTypeFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.DescriptorProto, com.google.protobuf.DescriptorProtos.DescriptorProto.Builder, com.google.protobuf.DescriptorProtos.DescriptorProtoOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                DescriptorProto, Builder, DescriptorProtoOrBuilder>
           getNestedTypeFieldBuilder() {
         if (nestedTypeBuilder_ == null) {
-          nestedTypeBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.DescriptorProto, com.google.protobuf.DescriptorProtos.DescriptorProto.Builder, com.google.protobuf.DescriptorProtos.DescriptorProtoOrBuilder>(
+          nestedTypeBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        DescriptorProto, Builder, DescriptorProtoOrBuilder>(
                   nestedType_,
                   ((bitField0_ & 0x00000008) != 0),
                   getParentForChildren(),
@@ -9474,8 +9474,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.EnumDescriptorProto, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProtoOrBuilder> enumTypeBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                EnumDescriptorProto, EnumDescriptorProto.Builder, EnumDescriptorProtoOrBuilder> enumTypeBuilder_;
 
       /**
        * <code>repeated .google.protobuf.EnumDescriptorProto enum_type = 4;</code>
@@ -9690,12 +9690,12 @@ public final class DescriptorProtos {
            getEnumTypeBuilderList() {
         return getEnumTypeFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.EnumDescriptorProto, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProtoOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                EnumDescriptorProto, EnumDescriptorProto.Builder, EnumDescriptorProtoOrBuilder>
           getEnumTypeFieldBuilder() {
         if (enumTypeBuilder_ == null) {
-          enumTypeBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.EnumDescriptorProto, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProtoOrBuilder>(
+          enumTypeBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        EnumDescriptorProto, EnumDescriptorProto.Builder, EnumDescriptorProtoOrBuilder>(
                   enumType_,
                   ((bitField0_ & 0x00000010) != 0),
                   getParentForChildren(),
@@ -9714,8 +9714,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange, com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange.Builder, com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRangeOrBuilder> extensionRangeBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                ExtensionRange, ExtensionRange.Builder, ExtensionRangeOrBuilder> extensionRangeBuilder_;
 
       /**
        * <code>repeated .google.protobuf.DescriptorProto.ExtensionRange extension_range = 5;</code>
@@ -9930,12 +9930,12 @@ public final class DescriptorProtos {
            getExtensionRangeBuilderList() {
         return getExtensionRangeFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange, com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange.Builder, com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRangeOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                ExtensionRange, ExtensionRange.Builder, ExtensionRangeOrBuilder>
           getExtensionRangeFieldBuilder() {
         if (extensionRangeBuilder_ == null) {
-          extensionRangeBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange, com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRange.Builder, com.google.protobuf.DescriptorProtos.DescriptorProto.ExtensionRangeOrBuilder>(
+          extensionRangeBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        ExtensionRange, ExtensionRange.Builder, ExtensionRangeOrBuilder>(
                   extensionRange_,
                   ((bitField0_ & 0x00000020) != 0),
                   getParentForChildren(),
@@ -9954,8 +9954,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.OneofDescriptorProto, com.google.protobuf.DescriptorProtos.OneofDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.OneofDescriptorProtoOrBuilder> oneofDeclBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                OneofDescriptorProto, OneofDescriptorProto.Builder, OneofDescriptorProtoOrBuilder> oneofDeclBuilder_;
 
       /**
        * <code>repeated .google.protobuf.OneofDescriptorProto oneof_decl = 8;</code>
@@ -10170,12 +10170,12 @@ public final class DescriptorProtos {
            getOneofDeclBuilderList() {
         return getOneofDeclFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.OneofDescriptorProto, com.google.protobuf.DescriptorProtos.OneofDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.OneofDescriptorProtoOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                OneofDescriptorProto, OneofDescriptorProto.Builder, OneofDescriptorProtoOrBuilder>
           getOneofDeclFieldBuilder() {
         if (oneofDeclBuilder_ == null) {
-          oneofDeclBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.OneofDescriptorProto, com.google.protobuf.DescriptorProtos.OneofDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.OneofDescriptorProtoOrBuilder>(
+          oneofDeclBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        OneofDescriptorProto, OneofDescriptorProto.Builder, OneofDescriptorProtoOrBuilder>(
                   oneofDecl_,
                   ((bitField0_ & 0x00000040) != 0),
                   getParentForChildren(),
@@ -10186,8 +10186,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.MessageOptions options_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.MessageOptions, com.google.protobuf.DescriptorProtos.MessageOptions.Builder, com.google.protobuf.DescriptorProtos.MessageOptionsOrBuilder> optionsBuilder_;
+      private SingleFieldBuilderV3Internal<
+                MessageOptions, MessageOptions.Builder, MessageOptionsOrBuilder> optionsBuilder_;
       /**
        * <code>optional .google.protobuf.MessageOptions options = 7;</code>
        * @return Whether the options field is set.
@@ -10292,12 +10292,12 @@ public final class DescriptorProtos {
       /**
        * <code>optional .google.protobuf.MessageOptions options = 7;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.MessageOptions, com.google.protobuf.DescriptorProtos.MessageOptions.Builder, com.google.protobuf.DescriptorProtos.MessageOptionsOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                MessageOptions, MessageOptions.Builder, MessageOptionsOrBuilder>
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.MessageOptions, com.google.protobuf.DescriptorProtos.MessageOptions.Builder, com.google.protobuf.DescriptorProtos.MessageOptionsOrBuilder>(
+          optionsBuilder_ = new SingleFieldBuilderV3Internal<
+                        MessageOptions, MessageOptions.Builder, MessageOptionsOrBuilder>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -10315,8 +10315,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.DescriptorProto.ReservedRange, com.google.protobuf.DescriptorProtos.DescriptorProto.ReservedRange.Builder, com.google.protobuf.DescriptorProtos.DescriptorProto.ReservedRangeOrBuilder> reservedRangeBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                ReservedRange, ReservedRange.Builder, ReservedRangeOrBuilder> reservedRangeBuilder_;
 
       /**
        * <code>repeated .google.protobuf.DescriptorProto.ReservedRange reserved_range = 9;</code>
@@ -10531,12 +10531,12 @@ public final class DescriptorProtos {
            getReservedRangeBuilderList() {
         return getReservedRangeFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.DescriptorProto.ReservedRange, com.google.protobuf.DescriptorProtos.DescriptorProto.ReservedRange.Builder, com.google.protobuf.DescriptorProtos.DescriptorProto.ReservedRangeOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                ReservedRange, ReservedRange.Builder, ReservedRangeOrBuilder>
           getReservedRangeFieldBuilder() {
         if (reservedRangeBuilder_ == null) {
-          reservedRangeBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.DescriptorProto.ReservedRange, com.google.protobuf.DescriptorProtos.DescriptorProto.ReservedRange.Builder, com.google.protobuf.DescriptorProtos.DescriptorProto.ReservedRangeOrBuilder>(
+          reservedRangeBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        ReservedRange, ReservedRange.Builder, ReservedRangeOrBuilder>(
                   reservedRange_,
                   ((bitField0_ & 0x00000100) != 0),
                   getParentForChildren(),
@@ -13176,8 +13176,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
 
       /**
        * <pre>
@@ -13464,12 +13464,12 @@ public final class DescriptorProtos {
            getUninterpretedOptionBuilderList() {
         return getUninterpretedOptionFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -13488,8 +13488,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.ExtensionRangeOptions.Declaration, com.google.protobuf.DescriptorProtos.ExtensionRangeOptions.Declaration.Builder, com.google.protobuf.DescriptorProtos.ExtensionRangeOptions.DeclarationOrBuilder> declarationBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                Declaration, Declaration.Builder, DeclarationOrBuilder> declarationBuilder_;
 
       /**
        * <pre>
@@ -13812,12 +13812,12 @@ public final class DescriptorProtos {
            getDeclarationBuilderList() {
         return getDeclarationFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.ExtensionRangeOptions.Declaration, com.google.protobuf.DescriptorProtos.ExtensionRangeOptions.Declaration.Builder, com.google.protobuf.DescriptorProtos.ExtensionRangeOptions.DeclarationOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                Declaration, Declaration.Builder, DeclarationOrBuilder>
           getDeclarationFieldBuilder() {
         if (declarationBuilder_ == null) {
-          declarationBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.ExtensionRangeOptions.Declaration, com.google.protobuf.DescriptorProtos.ExtensionRangeOptions.Declaration.Builder, com.google.protobuf.DescriptorProtos.ExtensionRangeOptions.DeclarationOrBuilder>(
+          declarationBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        Declaration, Declaration.Builder, DeclarationOrBuilder>(
                   declaration_,
                   ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
@@ -13828,8 +13828,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.FeatureSet features_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> featuresBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder> featuresBuilder_;
       /**
        * <pre>
        * Any features defined in the specific edition.
@@ -13970,12 +13970,12 @@ public final class DescriptorProtos {
        *
        * <code>optional .google.protobuf.FeatureSet features = 50;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>
           getFeaturesFieldBuilder() {
         if (featuresBuilder_ == null) {
-          featuresBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder>(
+          featuresBuilder_ = new SingleFieldBuilderV3Internal<
+                        FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>(
                   getFeatures(),
                   getParentForChildren(),
                   isClean());
@@ -16861,8 +16861,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.FieldOptions options_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldOptions, com.google.protobuf.DescriptorProtos.FieldOptions.Builder, com.google.protobuf.DescriptorProtos.FieldOptionsOrBuilder> optionsBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FieldOptions, FieldOptions.Builder, FieldOptionsOrBuilder> optionsBuilder_;
       /**
        * <code>optional .google.protobuf.FieldOptions options = 8;</code>
        * @return Whether the options field is set.
@@ -16967,12 +16967,12 @@ public final class DescriptorProtos {
       /**
        * <code>optional .google.protobuf.FieldOptions options = 8;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldOptions, com.google.protobuf.DescriptorProtos.FieldOptions.Builder, com.google.protobuf.DescriptorProtos.FieldOptionsOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FieldOptions, FieldOptions.Builder, FieldOptionsOrBuilder>
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FieldOptions, com.google.protobuf.DescriptorProtos.FieldOptions.Builder, com.google.protobuf.DescriptorProtos.FieldOptionsOrBuilder>(
+          optionsBuilder_ = new SingleFieldBuilderV3Internal<
+                        FieldOptions, FieldOptions.Builder, FieldOptionsOrBuilder>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -17805,8 +17805,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.OneofOptions options_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.OneofOptions, com.google.protobuf.DescriptorProtos.OneofOptions.Builder, com.google.protobuf.DescriptorProtos.OneofOptionsOrBuilder> optionsBuilder_;
+      private SingleFieldBuilderV3Internal<
+                OneofOptions, OneofOptions.Builder, OneofOptionsOrBuilder> optionsBuilder_;
       /**
        * <code>optional .google.protobuf.OneofOptions options = 2;</code>
        * @return Whether the options field is set.
@@ -17911,12 +17911,12 @@ public final class DescriptorProtos {
       /**
        * <code>optional .google.protobuf.OneofOptions options = 2;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.OneofOptions, com.google.protobuf.DescriptorProtos.OneofOptions.Builder, com.google.protobuf.DescriptorProtos.OneofOptionsOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                OneofOptions, OneofOptions.Builder, OneofOptionsOrBuilder>
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.OneofOptions, com.google.protobuf.DescriptorProtos.OneofOptions.Builder, com.google.protobuf.DescriptorProtos.OneofOptionsOrBuilder>(
+          optionsBuilder_ = new SingleFieldBuilderV3Internal<
+                        OneofOptions, OneofOptions.Builder, OneofOptionsOrBuilder>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -19796,8 +19796,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto, com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumValueDescriptorProtoOrBuilder> valueBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                EnumValueDescriptorProto, EnumValueDescriptorProto.Builder, EnumValueDescriptorProtoOrBuilder> valueBuilder_;
 
       /**
        * <code>repeated .google.protobuf.EnumValueDescriptorProto value = 2;</code>
@@ -20012,12 +20012,12 @@ public final class DescriptorProtos {
            getValueBuilderList() {
         return getValueFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto, com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumValueDescriptorProtoOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                EnumValueDescriptorProto, EnumValueDescriptorProto.Builder, EnumValueDescriptorProtoOrBuilder>
           getValueFieldBuilder() {
         if (valueBuilder_ == null) {
-          valueBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto, com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.EnumValueDescriptorProtoOrBuilder>(
+          valueBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        EnumValueDescriptorProto, EnumValueDescriptorProto.Builder, EnumValueDescriptorProtoOrBuilder>(
                   value_,
                   ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
@@ -20028,8 +20028,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.EnumOptions options_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.EnumOptions, com.google.protobuf.DescriptorProtos.EnumOptions.Builder, com.google.protobuf.DescriptorProtos.EnumOptionsOrBuilder> optionsBuilder_;
+      private SingleFieldBuilderV3Internal<
+                EnumOptions, EnumOptions.Builder, EnumOptionsOrBuilder> optionsBuilder_;
       /**
        * <code>optional .google.protobuf.EnumOptions options = 3;</code>
        * @return Whether the options field is set.
@@ -20134,12 +20134,12 @@ public final class DescriptorProtos {
       /**
        * <code>optional .google.protobuf.EnumOptions options = 3;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.EnumOptions, com.google.protobuf.DescriptorProtos.EnumOptions.Builder, com.google.protobuf.DescriptorProtos.EnumOptionsOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                EnumOptions, EnumOptions.Builder, EnumOptionsOrBuilder>
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.EnumOptions, com.google.protobuf.DescriptorProtos.EnumOptions.Builder, com.google.protobuf.DescriptorProtos.EnumOptionsOrBuilder>(
+          optionsBuilder_ = new SingleFieldBuilderV3Internal<
+                        EnumOptions, EnumOptions.Builder, EnumOptionsOrBuilder>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -20157,8 +20157,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.EnumDescriptorProto.EnumReservedRange, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.EnumReservedRange.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.EnumReservedRangeOrBuilder> reservedRangeBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                EnumReservedRange, EnumReservedRange.Builder, EnumReservedRangeOrBuilder> reservedRangeBuilder_;
 
       /**
        * <pre>
@@ -20481,12 +20481,12 @@ public final class DescriptorProtos {
            getReservedRangeBuilderList() {
         return getReservedRangeFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.EnumDescriptorProto.EnumReservedRange, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.EnumReservedRange.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.EnumReservedRangeOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                EnumReservedRange, EnumReservedRange.Builder, EnumReservedRangeOrBuilder>
           getReservedRangeFieldBuilder() {
         if (reservedRangeBuilder_ == null) {
-          reservedRangeBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.EnumDescriptorProto.EnumReservedRange, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.EnumReservedRange.Builder, com.google.protobuf.DescriptorProtos.EnumDescriptorProto.EnumReservedRangeOrBuilder>(
+          reservedRangeBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        EnumReservedRange, EnumReservedRange.Builder, EnumReservedRangeOrBuilder>(
                   reservedRange_,
                   ((bitField0_ & 0x00000008) != 0),
                   getParentForChildren(),
@@ -21438,8 +21438,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.EnumValueOptions options_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.EnumValueOptions, com.google.protobuf.DescriptorProtos.EnumValueOptions.Builder, com.google.protobuf.DescriptorProtos.EnumValueOptionsOrBuilder> optionsBuilder_;
+      private SingleFieldBuilderV3Internal<
+                EnumValueOptions, EnumValueOptions.Builder, EnumValueOptionsOrBuilder> optionsBuilder_;
       /**
        * <code>optional .google.protobuf.EnumValueOptions options = 3;</code>
        * @return Whether the options field is set.
@@ -21544,12 +21544,12 @@ public final class DescriptorProtos {
       /**
        * <code>optional .google.protobuf.EnumValueOptions options = 3;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.EnumValueOptions, com.google.protobuf.DescriptorProtos.EnumValueOptions.Builder, com.google.protobuf.DescriptorProtos.EnumValueOptionsOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                EnumValueOptions, EnumValueOptions.Builder, EnumValueOptionsOrBuilder>
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.EnumValueOptions, com.google.protobuf.DescriptorProtos.EnumValueOptions.Builder, com.google.protobuf.DescriptorProtos.EnumValueOptionsOrBuilder>(
+          optionsBuilder_ = new SingleFieldBuilderV3Internal<
+                        EnumValueOptions, EnumValueOptions.Builder, EnumValueOptionsOrBuilder>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -22404,8 +22404,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.MethodDescriptorProto, com.google.protobuf.DescriptorProtos.MethodDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.MethodDescriptorProtoOrBuilder> methodBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                MethodDescriptorProto, MethodDescriptorProto.Builder, MethodDescriptorProtoOrBuilder> methodBuilder_;
 
       /**
        * <code>repeated .google.protobuf.MethodDescriptorProto method = 2;</code>
@@ -22620,12 +22620,12 @@ public final class DescriptorProtos {
            getMethodBuilderList() {
         return getMethodFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.MethodDescriptorProto, com.google.protobuf.DescriptorProtos.MethodDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.MethodDescriptorProtoOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                MethodDescriptorProto, MethodDescriptorProto.Builder, MethodDescriptorProtoOrBuilder>
           getMethodFieldBuilder() {
         if (methodBuilder_ == null) {
-          methodBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.MethodDescriptorProto, com.google.protobuf.DescriptorProtos.MethodDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.MethodDescriptorProtoOrBuilder>(
+          methodBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        MethodDescriptorProto, MethodDescriptorProto.Builder, MethodDescriptorProtoOrBuilder>(
                   method_,
                   ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
@@ -22636,8 +22636,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.ServiceOptions options_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.ServiceOptions, com.google.protobuf.DescriptorProtos.ServiceOptions.Builder, com.google.protobuf.DescriptorProtos.ServiceOptionsOrBuilder> optionsBuilder_;
+      private SingleFieldBuilderV3Internal<
+                ServiceOptions, ServiceOptions.Builder, ServiceOptionsOrBuilder> optionsBuilder_;
       /**
        * <code>optional .google.protobuf.ServiceOptions options = 3;</code>
        * @return Whether the options field is set.
@@ -22742,12 +22742,12 @@ public final class DescriptorProtos {
       /**
        * <code>optional .google.protobuf.ServiceOptions options = 3;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.ServiceOptions, com.google.protobuf.DescriptorProtos.ServiceOptions.Builder, com.google.protobuf.DescriptorProtos.ServiceOptionsOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                ServiceOptions, ServiceOptions.Builder, ServiceOptionsOrBuilder>
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.ServiceOptions, com.google.protobuf.DescriptorProtos.ServiceOptions.Builder, com.google.protobuf.DescriptorProtos.ServiceOptionsOrBuilder>(
+          optionsBuilder_ = new SingleFieldBuilderV3Internal<
+                        ServiceOptions, ServiceOptions.Builder, ServiceOptionsOrBuilder>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -24010,8 +24010,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.MethodOptions options_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.MethodOptions, com.google.protobuf.DescriptorProtos.MethodOptions.Builder, com.google.protobuf.DescriptorProtos.MethodOptionsOrBuilder> optionsBuilder_;
+      private SingleFieldBuilderV3Internal<
+                MethodOptions, MethodOptions.Builder, MethodOptionsOrBuilder> optionsBuilder_;
       /**
        * <code>optional .google.protobuf.MethodOptions options = 4;</code>
        * @return Whether the options field is set.
@@ -24116,12 +24116,12 @@ public final class DescriptorProtos {
       /**
        * <code>optional .google.protobuf.MethodOptions options = 4;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.MethodOptions, com.google.protobuf.DescriptorProtos.MethodOptions.Builder, com.google.protobuf.DescriptorProtos.MethodOptionsOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                MethodOptions, MethodOptions.Builder, MethodOptionsOrBuilder>
           getOptionsFieldBuilder() {
         if (optionsBuilder_ == null) {
-          optionsBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.MethodOptions, com.google.protobuf.DescriptorProtos.MethodOptions.Builder, com.google.protobuf.DescriptorProtos.MethodOptionsOrBuilder>(
+          optionsBuilder_ = new SingleFieldBuilderV3Internal<
+                        MethodOptions, MethodOptions.Builder, MethodOptionsOrBuilder>(
                   getOptions(),
                   getParentForChildren(),
                   isClean());
@@ -29012,8 +29012,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.FeatureSet features_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> featuresBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder> featuresBuilder_;
       /**
        * <pre>
        * Any features defined in the specific edition.
@@ -29181,12 +29181,12 @@ public final class DescriptorProtos {
        *
        * <code>optional .google.protobuf.FeatureSet features = 50;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>
           getFeaturesFieldBuilder() {
         if (featuresBuilder_ == null) {
-          featuresBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder>(
+          featuresBuilder_ = new SingleFieldBuilderV3Internal<
+                        FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>(
                   getFeatures(),
                   getParentForChildren(),
                   isClean());
@@ -29204,8 +29204,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
 
       /**
        * <pre>
@@ -29510,12 +29510,12 @@ public final class DescriptorProtos {
            getUninterpretedOptionBuilderList() {
         return getUninterpretedOptionFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00100000) != 0),
                   getParentForChildren(),
@@ -31390,8 +31390,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.FeatureSet features_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> featuresBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder> featuresBuilder_;
       /**
        * <pre>
        * Any features defined in the specific edition.
@@ -31559,12 +31559,12 @@ public final class DescriptorProtos {
        *
        * <code>optional .google.protobuf.FeatureSet features = 12;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>
           getFeaturesFieldBuilder() {
         if (featuresBuilder_ == null) {
-          featuresBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder>(
+          featuresBuilder_ = new SingleFieldBuilderV3Internal<
+                        FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>(
                   getFeatures(),
                   getParentForChildren(),
                   isClean());
@@ -31582,8 +31582,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
 
       /**
        * <pre>
@@ -31870,12 +31870,12 @@ public final class DescriptorProtos {
            getUninterpretedOptionBuilderList() {
         return getUninterpretedOptionFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000040) != 0),
                   getParentForChildren(),
@@ -37054,8 +37054,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldOptions.EditionDefault, com.google.protobuf.DescriptorProtos.FieldOptions.EditionDefault.Builder, com.google.protobuf.DescriptorProtos.FieldOptions.EditionDefaultOrBuilder> editionDefaultsBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                EditionDefault, EditionDefault.Builder, EditionDefaultOrBuilder> editionDefaultsBuilder_;
 
       /**
        * <code>repeated .google.protobuf.FieldOptions.EditionDefault edition_defaults = 20;</code>
@@ -37270,12 +37270,12 @@ public final class DescriptorProtos {
            getEditionDefaultsBuilderList() {
         return getEditionDefaultsFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldOptions.EditionDefault, com.google.protobuf.DescriptorProtos.FieldOptions.EditionDefault.Builder, com.google.protobuf.DescriptorProtos.FieldOptions.EditionDefaultOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                EditionDefault, EditionDefault.Builder, EditionDefaultOrBuilder>
           getEditionDefaultsFieldBuilder() {
         if (editionDefaultsBuilder_ == null) {
-          editionDefaultsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FieldOptions.EditionDefault, com.google.protobuf.DescriptorProtos.FieldOptions.EditionDefault.Builder, com.google.protobuf.DescriptorProtos.FieldOptions.EditionDefaultOrBuilder>(
+          editionDefaultsBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        EditionDefault, EditionDefault.Builder, EditionDefaultOrBuilder>(
                   editionDefaults_,
                   ((bitField0_ & 0x00000400) != 0),
                   getParentForChildren(),
@@ -37286,8 +37286,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.FeatureSet features_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> featuresBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder> featuresBuilder_;
       /**
        * <pre>
        * Any features defined in the specific edition.
@@ -37455,12 +37455,12 @@ public final class DescriptorProtos {
        *
        * <code>optional .google.protobuf.FeatureSet features = 21;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>
           getFeaturesFieldBuilder() {
         if (featuresBuilder_ == null) {
-          featuresBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder>(
+          featuresBuilder_ = new SingleFieldBuilderV3Internal<
+                        FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>(
                   getFeatures(),
                   getParentForChildren(),
                   isClean());
@@ -37470,8 +37470,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport featureSupport_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport, com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport.Builder, com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupportOrBuilder> featureSupportBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FeatureSupport, FeatureSupport.Builder, FeatureSupportOrBuilder> featureSupportBuilder_;
       /**
        * <code>optional .google.protobuf.FieldOptions.FeatureSupport feature_support = 22;</code>
        * @return Whether the featureSupport field is set.
@@ -37576,12 +37576,12 @@ public final class DescriptorProtos {
       /**
        * <code>optional .google.protobuf.FieldOptions.FeatureSupport feature_support = 22;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport, com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport.Builder, com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupportOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FeatureSupport, FeatureSupport.Builder, FeatureSupportOrBuilder>
           getFeatureSupportFieldBuilder() {
         if (featureSupportBuilder_ == null) {
-          featureSupportBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport, com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport.Builder, com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupportOrBuilder>(
+          featureSupportBuilder_ = new SingleFieldBuilderV3Internal<
+                        FeatureSupport, FeatureSupport.Builder, FeatureSupportOrBuilder>(
                   getFeatureSupport(),
                   getParentForChildren(),
                   isClean());
@@ -37599,8 +37599,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
 
       /**
        * <pre>
@@ -37887,12 +37887,12 @@ public final class DescriptorProtos {
            getUninterpretedOptionBuilderList() {
         return getUninterpretedOptionFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00002000) != 0),
                   getParentForChildren(),
@@ -38683,8 +38683,8 @@ public final class DescriptorProtos {
       private int bitField0_;
 
       private com.google.protobuf.DescriptorProtos.FeatureSet features_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> featuresBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder> featuresBuilder_;
       /**
        * <pre>
        * Any features defined in the specific edition.
@@ -38852,12 +38852,12 @@ public final class DescriptorProtos {
        *
        * <code>optional .google.protobuf.FeatureSet features = 1;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>
           getFeaturesFieldBuilder() {
         if (featuresBuilder_ == null) {
-          featuresBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder>(
+          featuresBuilder_ = new SingleFieldBuilderV3Internal<
+                        FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>(
                   getFeatures(),
                   getParentForChildren(),
                   isClean());
@@ -38875,8 +38875,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
 
       /**
        * <pre>
@@ -39163,12 +39163,12 @@ public final class DescriptorProtos {
            getUninterpretedOptionBuilderList() {
         return getUninterpretedOptionFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000002) != 0),
                   getParentForChildren(),
@@ -40443,8 +40443,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.FeatureSet features_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> featuresBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder> featuresBuilder_;
       /**
        * <pre>
        * Any features defined in the specific edition.
@@ -40612,12 +40612,12 @@ public final class DescriptorProtos {
        *
        * <code>optional .google.protobuf.FeatureSet features = 7;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>
           getFeaturesFieldBuilder() {
         if (featuresBuilder_ == null) {
-          featuresBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder>(
+          featuresBuilder_ = new SingleFieldBuilderV3Internal<
+                        FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>(
                   getFeatures(),
                   getParentForChildren(),
                   isClean());
@@ -40635,8 +40635,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
 
       /**
        * <pre>
@@ -40923,12 +40923,12 @@ public final class DescriptorProtos {
            getUninterpretedOptionBuilderList() {
         return getUninterpretedOptionFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000010) != 0),
                   getParentForChildren(),
@@ -42062,8 +42062,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.FeatureSet features_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> featuresBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder> featuresBuilder_;
       /**
        * <pre>
        * Any features defined in the specific edition.
@@ -42231,12 +42231,12 @@ public final class DescriptorProtos {
        *
        * <code>optional .google.protobuf.FeatureSet features = 2;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>
           getFeaturesFieldBuilder() {
         if (featuresBuilder_ == null) {
-          featuresBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder>(
+          featuresBuilder_ = new SingleFieldBuilderV3Internal<
+                        FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>(
                   getFeatures(),
                   getParentForChildren(),
                   isClean());
@@ -42310,8 +42310,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport featureSupport_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport, com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport.Builder, com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupportOrBuilder> featureSupportBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FieldOptions.FeatureSupport, FieldOptions.FeatureSupport.Builder, FieldOptions.FeatureSupportOrBuilder> featureSupportBuilder_;
       /**
        * <pre>
        * Information about the support window of a feature value.
@@ -42452,12 +42452,12 @@ public final class DescriptorProtos {
        *
        * <code>optional .google.protobuf.FieldOptions.FeatureSupport feature_support = 4;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport, com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport.Builder, com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupportOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FieldOptions.FeatureSupport, FieldOptions.FeatureSupport.Builder, FieldOptions.FeatureSupportOrBuilder>
           getFeatureSupportFieldBuilder() {
         if (featureSupportBuilder_ == null) {
-          featureSupportBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport, com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupport.Builder, com.google.protobuf.DescriptorProtos.FieldOptions.FeatureSupportOrBuilder>(
+          featureSupportBuilder_ = new SingleFieldBuilderV3Internal<
+                        FieldOptions.FeatureSupport, FieldOptions.FeatureSupport.Builder, FieldOptions.FeatureSupportOrBuilder>(
                   getFeatureSupport(),
                   getParentForChildren(),
                   isClean());
@@ -42475,8 +42475,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
 
       /**
        * <pre>
@@ -42763,12 +42763,12 @@ public final class DescriptorProtos {
            getUninterpretedOptionBuilderList() {
         return getUninterpretedOptionFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000010) != 0),
                   getParentForChildren(),
@@ -43647,8 +43647,8 @@ public final class DescriptorProtos {
       private int bitField0_;
 
       private com.google.protobuf.DescriptorProtos.FeatureSet features_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> featuresBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder> featuresBuilder_;
       /**
        * <pre>
        * Any features defined in the specific edition.
@@ -43816,12 +43816,12 @@ public final class DescriptorProtos {
        *
        * <code>optional .google.protobuf.FeatureSet features = 34;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>
           getFeaturesFieldBuilder() {
         if (featuresBuilder_ == null) {
-          featuresBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder>(
+          featuresBuilder_ = new SingleFieldBuilderV3Internal<
+                        FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>(
                   getFeatures(),
                   getParentForChildren(),
                   isClean());
@@ -43907,8 +43907,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
 
       /**
        * <pre>
@@ -44195,12 +44195,12 @@ public final class DescriptorProtos {
            getUninterpretedOptionBuilderList() {
         return getUninterpretedOptionFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000004) != 0),
                   getParentForChildren(),
@@ -45381,8 +45381,8 @@ public final class DescriptorProtos {
       }
 
       private com.google.protobuf.DescriptorProtos.FeatureSet features_;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> featuresBuilder_;
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder> featuresBuilder_;
       /**
        * <pre>
        * Any features defined in the specific edition.
@@ -45550,12 +45550,12 @@ public final class DescriptorProtos {
        *
        * <code>optional .google.protobuf.FeatureSet features = 35;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> 
+      private SingleFieldBuilderV3Internal<
+                FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>
           getFeaturesFieldBuilder() {
         if (featuresBuilder_ == null) {
-          featuresBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder>(
+          featuresBuilder_ = new SingleFieldBuilderV3Internal<
+                        FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>(
                   getFeatures(),
                   getParentForChildren(),
                   isClean());
@@ -45573,8 +45573,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder> uninterpretedOptionBuilder_;
 
       /**
        * <pre>
@@ -45861,12 +45861,12 @@ public final class DescriptorProtos {
            getUninterpretedOptionBuilderList() {
         return getUninterpretedOptionFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>
           getUninterpretedOptionFieldBuilder() {
         if (uninterpretedOptionBuilder_ == null) {
-          uninterpretedOptionBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption, com.google.protobuf.DescriptorProtos.UninterpretedOption.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOptionOrBuilder>(
+          uninterpretedOptionBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        UninterpretedOption, UninterpretedOption.Builder, UninterpretedOptionOrBuilder>(
                   uninterpretedOption_,
                   ((bitField0_ & 0x00000008) != 0),
                   getParentForChildren(),
@@ -47638,8 +47638,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart, com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePartOrBuilder> nameBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                NamePart, NamePart.Builder, NamePartOrBuilder> nameBuilder_;
 
       /**
        * <code>repeated .google.protobuf.UninterpretedOption.NamePart name = 2;</code>
@@ -47854,12 +47854,12 @@ public final class DescriptorProtos {
            getNameBuilderList() {
         return getNameFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart, com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePartOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                NamePart, NamePart.Builder, NamePartOrBuilder>
           getNameFieldBuilder() {
         if (nameBuilder_ == null) {
-          nameBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart, com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePart.Builder, com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePartOrBuilder>(
+          nameBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        NamePart, NamePart.Builder, NamePartOrBuilder>(
                   name_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -50848,8 +50848,8 @@ public final class DescriptorProtos {
         }
 
         private com.google.protobuf.DescriptorProtos.FeatureSet overridableFeatures_;
-        private com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> overridableFeaturesBuilder_;
+        private SingleFieldBuilderV3Internal<
+                    FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder> overridableFeaturesBuilder_;
         /**
          * <pre>
          * Defaults of features that can be overridden in this edition.
@@ -50990,12 +50990,12 @@ public final class DescriptorProtos {
          *
          * <code>optional .google.protobuf.FeatureSet overridable_features = 4;</code>
          */
-        private com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> 
+        private SingleFieldBuilderV3Internal<
+                    FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>
             getOverridableFeaturesFieldBuilder() {
           if (overridableFeaturesBuilder_ == null) {
-            overridableFeaturesBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder>(
+            overridableFeaturesBuilder_ = new SingleFieldBuilderV3Internal<
+                            FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>(
                     getOverridableFeatures(),
                     getParentForChildren(),
                     isClean());
@@ -51005,8 +51005,8 @@ public final class DescriptorProtos {
         }
 
         private com.google.protobuf.DescriptorProtos.FeatureSet fixedFeatures_;
-        private com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> fixedFeaturesBuilder_;
+        private SingleFieldBuilderV3Internal<
+                    FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder> fixedFeaturesBuilder_;
         /**
          * <pre>
          * Defaults of features that can't be overridden in this edition.
@@ -51147,12 +51147,12 @@ public final class DescriptorProtos {
          *
          * <code>optional .google.protobuf.FeatureSet fixed_features = 5;</code>
          */
-        private com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder> 
+        private SingleFieldBuilderV3Internal<
+                    FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>
             getFixedFeaturesFieldBuilder() {
           if (fixedFeaturesBuilder_ == null) {
-            fixedFeaturesBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-                com.google.protobuf.DescriptorProtos.FeatureSet, com.google.protobuf.DescriptorProtos.FeatureSet.Builder, com.google.protobuf.DescriptorProtos.FeatureSetOrBuilder>(
+            fixedFeaturesBuilder_ = new SingleFieldBuilderV3Internal<
+                            FeatureSet, FeatureSet.Builder, FeatureSetOrBuilder>(
                     getFixedFeatures(),
                     getParentForChildren(),
                     isClean());
@@ -51795,8 +51795,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSetDefaults.FeatureSetEditionDefault, com.google.protobuf.DescriptorProtos.FeatureSetDefaults.FeatureSetEditionDefault.Builder, com.google.protobuf.DescriptorProtos.FeatureSetDefaults.FeatureSetEditionDefaultOrBuilder> defaultsBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                FeatureSetEditionDefault, FeatureSetEditionDefault.Builder, FeatureSetEditionDefaultOrBuilder> defaultsBuilder_;
 
       /**
        * <code>repeated .google.protobuf.FeatureSetDefaults.FeatureSetEditionDefault defaults = 1;</code>
@@ -52011,12 +52011,12 @@ public final class DescriptorProtos {
            getDefaultsBuilderList() {
         return getDefaultsFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.FeatureSetDefaults.FeatureSetEditionDefault, com.google.protobuf.DescriptorProtos.FeatureSetDefaults.FeatureSetEditionDefault.Builder, com.google.protobuf.DescriptorProtos.FeatureSetDefaults.FeatureSetEditionDefaultOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                FeatureSetEditionDefault, FeatureSetEditionDefault.Builder, FeatureSetEditionDefaultOrBuilder>
           getDefaultsFieldBuilder() {
         if (defaultsBuilder_ == null) {
-          defaultsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.FeatureSetDefaults.FeatureSetEditionDefault, com.google.protobuf.DescriptorProtos.FeatureSetDefaults.FeatureSetEditionDefault.Builder, com.google.protobuf.DescriptorProtos.FeatureSetDefaults.FeatureSetEditionDefaultOrBuilder>(
+          defaultsBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        FeatureSetEditionDefault, FeatureSetEditionDefault.Builder, FeatureSetEditionDefaultOrBuilder>(
                   defaults_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -55616,8 +55616,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location, com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location.Builder, com.google.protobuf.DescriptorProtos.SourceCodeInfo.LocationOrBuilder> locationBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                Location, Location.Builder, LocationOrBuilder> locationBuilder_;
 
       /**
        * <pre>
@@ -56660,12 +56660,12 @@ public final class DescriptorProtos {
            getLocationBuilderList() {
         return getLocationFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location, com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location.Builder, com.google.protobuf.DescriptorProtos.SourceCodeInfo.LocationOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                Location, Location.Builder, LocationOrBuilder>
           getLocationFieldBuilder() {
         if (locationBuilder_ == null) {
-          locationBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location, com.google.protobuf.DescriptorProtos.SourceCodeInfo.Location.Builder, com.google.protobuf.DescriptorProtos.SourceCodeInfo.LocationOrBuilder>(
+          locationBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        Location, Location.Builder, LocationOrBuilder>(
                   location_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -58704,8 +58704,8 @@ public final class DescriptorProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.Annotation, com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.Annotation.Builder, com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.AnnotationOrBuilder> annotationBuilder_;
+      private RepeatedFieldBuilderV3Internal<
+                Annotation, Annotation.Builder, AnnotationOrBuilder> annotationBuilder_;
 
       /**
        * <pre>
@@ -59010,12 +59010,12 @@ public final class DescriptorProtos {
            getAnnotationBuilderList() {
         return getAnnotationFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.Annotation, com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.Annotation.Builder, com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.AnnotationOrBuilder> 
+      private RepeatedFieldBuilderV3Internal<
+                Annotation, Annotation.Builder, AnnotationOrBuilder>
           getAnnotationFieldBuilder() {
         if (annotationBuilder_ == null) {
-          annotationBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.Annotation, com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.Annotation.Builder, com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.AnnotationOrBuilder>(
+          annotationBuilder_ = new RepeatedFieldBuilderV3Internal<
+                        Annotation, Annotation.Builder, AnnotationOrBuilder>(
                   annotation_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),

--- a/protobuf-api/src/main/java/com/google/protobuf/Enum.java
+++ b/protobuf-api/src/main/java/com/google/protobuf/Enum.java
@@ -993,8 +993,8 @@ private static final long serialVersionUID = 0L;
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.EnumValue, com.google.protobuf.EnumValue.Builder, com.google.protobuf.EnumValueOrBuilder> enumvalueBuilder_;
+    private RepeatedFieldBuilderV3Internal<
+            EnumValue, EnumValue.Builder, EnumValueOrBuilder> enumvalueBuilder_;
 
     /**
      * <pre>
@@ -1281,12 +1281,12 @@ private static final long serialVersionUID = 0L;
          getEnumvalueBuilderList() {
       return getEnumvalueFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.EnumValue, com.google.protobuf.EnumValue.Builder, com.google.protobuf.EnumValueOrBuilder> 
+    private RepeatedFieldBuilderV3Internal<
+            EnumValue, EnumValue.Builder, EnumValueOrBuilder>
         getEnumvalueFieldBuilder() {
       if (enumvalueBuilder_ == null) {
-        enumvalueBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.protobuf.EnumValue, com.google.protobuf.EnumValue.Builder, com.google.protobuf.EnumValueOrBuilder>(
+        enumvalueBuilder_ = new RepeatedFieldBuilderV3Internal<
+                    EnumValue, EnumValue.Builder, EnumValueOrBuilder>(
                 enumvalue_,
                 ((bitField0_ & 0x00000002) != 0),
                 getParentForChildren(),
@@ -1305,8 +1305,8 @@ private static final long serialVersionUID = 0L;
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> optionsBuilder_;
+    private RepeatedFieldBuilderV3Internal<
+            Option, Option.Builder, OptionOrBuilder> optionsBuilder_;
 
     /**
      * <pre>
@@ -1593,12 +1593,12 @@ private static final long serialVersionUID = 0L;
          getOptionsBuilderList() {
       return getOptionsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> 
+    private RepeatedFieldBuilderV3Internal<
+            Option, Option.Builder, OptionOrBuilder>
         getOptionsFieldBuilder() {
       if (optionsBuilder_ == null) {
-        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder>(
+        optionsBuilder_ = new RepeatedFieldBuilderV3Internal<
+                    Option, Option.Builder, OptionOrBuilder>(
                 options_,
                 ((bitField0_ & 0x00000004) != 0),
                 getParentForChildren(),
@@ -1609,8 +1609,8 @@ private static final long serialVersionUID = 0L;
     }
 
     private com.google.protobuf.SourceContext sourceContext_;
-    private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder> sourceContextBuilder_;
+    private SingleFieldBuilderV3Internal<
+            SourceContext, SourceContext.Builder, SourceContextOrBuilder> sourceContextBuilder_;
     /**
      * <pre>
      * The source context.
@@ -1751,12 +1751,12 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.google.protobuf.SourceContext source_context = 4;</code>
      */
-    private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder> 
+    private SingleFieldBuilderV3Internal<
+            SourceContext, SourceContext.Builder, SourceContextOrBuilder>
         getSourceContextFieldBuilder() {
       if (sourceContextBuilder_ == null) {
-        sourceContextBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder>(
+        sourceContextBuilder_ = new SingleFieldBuilderV3Internal<
+                    SourceContext, SourceContext.Builder, SourceContextOrBuilder>(
                 getSourceContext(),
                 getParentForChildren(),
                 isClean());

--- a/protobuf-api/src/main/java/com/google/protobuf/EnumValue.java
+++ b/protobuf-api/src/main/java/com/google/protobuf/EnumValue.java
@@ -738,8 +738,8 @@ private static final long serialVersionUID = 0L;
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> optionsBuilder_;
+    private RepeatedFieldBuilderV3Internal<
+            Option, Option.Builder, OptionOrBuilder> optionsBuilder_;
 
     /**
      * <pre>
@@ -1026,12 +1026,12 @@ private static final long serialVersionUID = 0L;
          getOptionsBuilderList() {
       return getOptionsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> 
+    private RepeatedFieldBuilderV3Internal<
+            Option, Option.Builder, OptionOrBuilder>
         getOptionsFieldBuilder() {
       if (optionsBuilder_ == null) {
-        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder>(
+        optionsBuilder_ = new RepeatedFieldBuilderV3Internal<
+                    Option, Option.Builder, OptionOrBuilder>(
                 options_,
                 ((bitField0_ & 0x00000004) != 0),
                 getParentForChildren(),

--- a/protobuf-api/src/main/java/com/google/protobuf/Field.java
+++ b/protobuf-api/src/main/java/com/google/protobuf/Field.java
@@ -2045,8 +2045,8 @@ private static final long serialVersionUID = 0L;
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> optionsBuilder_;
+    private RepeatedFieldBuilderV3Internal<
+            Option, Option.Builder, OptionOrBuilder> optionsBuilder_;
 
     /**
      * <pre>
@@ -2333,12 +2333,12 @@ private static final long serialVersionUID = 0L;
          getOptionsBuilderList() {
       return getOptionsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> 
+    private RepeatedFieldBuilderV3Internal<
+            Option, Option.Builder, OptionOrBuilder>
         getOptionsFieldBuilder() {
       if (optionsBuilder_ == null) {
-        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder>(
+        optionsBuilder_ = new RepeatedFieldBuilderV3Internal<
+                    Option, Option.Builder, OptionOrBuilder>(
                 options_,
                 ((bitField0_ & 0x00000080) != 0),
                 getParentForChildren(),

--- a/protobuf-api/src/main/java/com/google/protobuf/ListValue.java
+++ b/protobuf-api/src/main/java/com/google/protobuf/ListValue.java
@@ -496,8 +496,8 @@ private static final long serialVersionUID = 0L;
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Value, com.google.protobuf.Value.Builder, com.google.protobuf.ValueOrBuilder> valuesBuilder_;
+    private RepeatedFieldBuilderV3Internal<
+            Value, Value.Builder, ValueOrBuilder> valuesBuilder_;
 
     /**
      * <pre>
@@ -784,12 +784,12 @@ private static final long serialVersionUID = 0L;
          getValuesBuilderList() {
       return getValuesFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Value, com.google.protobuf.Value.Builder, com.google.protobuf.ValueOrBuilder> 
+    private RepeatedFieldBuilderV3Internal<
+            Value, Value.Builder, ValueOrBuilder>
         getValuesFieldBuilder() {
       if (valuesBuilder_ == null) {
-        valuesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.protobuf.Value, com.google.protobuf.Value.Builder, com.google.protobuf.ValueOrBuilder>(
+        valuesBuilder_ = new RepeatedFieldBuilderV3Internal<
+                    Value, Value.Builder, ValueOrBuilder>(
                 values_,
                 ((bitField0_ & 0x00000001) != 0),
                 getParentForChildren(),

--- a/protobuf-api/src/main/java/com/google/protobuf/Method.java
+++ b/protobuf-api/src/main/java/com/google/protobuf/Method.java
@@ -1199,8 +1199,8 @@ private static final long serialVersionUID = 0L;
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> optionsBuilder_;
+    private RepeatedFieldBuilderV3Internal<
+            Option, Option.Builder, OptionOrBuilder> optionsBuilder_;
 
     /**
      * <pre>
@@ -1487,12 +1487,12 @@ private static final long serialVersionUID = 0L;
          getOptionsBuilderList() {
       return getOptionsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> 
+    private RepeatedFieldBuilderV3Internal<
+            Option, Option.Builder, OptionOrBuilder>
         getOptionsFieldBuilder() {
       if (optionsBuilder_ == null) {
-        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder>(
+        optionsBuilder_ = new RepeatedFieldBuilderV3Internal<
+                    Option, Option.Builder, OptionOrBuilder>(
                 options_,
                 ((bitField0_ & 0x00000020) != 0),
                 getParentForChildren(),

--- a/protobuf-api/src/main/java/com/google/protobuf/Option.java
+++ b/protobuf-api/src/main/java/com/google/protobuf/Option.java
@@ -630,8 +630,8 @@ private static final long serialVersionUID = 0L;
     }
 
     private com.google.protobuf.Any value_;
-    private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder> valueBuilder_;
+    private SingleFieldBuilderV3Internal<
+            Any, Any.Builder, AnyOrBuilder> valueBuilder_;
     /**
      * <pre>
      * The option's value packed in an Any message. If the value is a primitive,
@@ -799,12 +799,12 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.google.protobuf.Any value = 2;</code>
      */
-    private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder> 
+    private SingleFieldBuilderV3Internal<
+            Any, Any.Builder, AnyOrBuilder>
         getValueFieldBuilder() {
       if (valueBuilder_ == null) {
-        valueBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.Any, com.google.protobuf.Any.Builder, com.google.protobuf.AnyOrBuilder>(
+        valueBuilder_ = new SingleFieldBuilderV3Internal<
+                    Any, Any.Builder, AnyOrBuilder>(
                 getValue(),
                 getParentForChildren(),
                 isClean());

--- a/protobuf-api/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3Internal.java
+++ b/protobuf-api/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3Internal.java
@@ -36,7 +36,7 @@ import java.util.RandomAccess;
  * @param <IType> the common interface for the message and the builder
  * @author jonp@google.com (Jon Perlow)
  */
-public class RepeatedFieldBuilderV3<
+class RepeatedFieldBuilderV3Internal<
         MType extends Message,
         BType extends Message.Builder,
         IType extends MessageOrBuilder>
@@ -54,7 +54,7 @@ public class RepeatedFieldBuilderV3<
 
   // List of builders. May be null, in which case, no nested builders were
   // created. If not null, entries represent the builder for that index.
-  private List<SingleFieldBuilderV3<MType, BType, IType>> builders;
+  private List<SingleFieldBuilderV3Internal<MType, BType, IType>> builders;
 
   // Here are the invariants for messages and builders:
   // 1. messages is never null and its count corresponds to the number of items
@@ -101,7 +101,7 @@ public class RepeatedFieldBuilderV3<
    * @param parent a listener to notify of changes
    * @param isClean whether the builder is initially marked clean
    */
-  public RepeatedFieldBuilderV3(
+  public RepeatedFieldBuilderV3Internal(
       List<MType> messages,
       boolean isMessagesListMutable,
       Message.BuilderParent parent,
@@ -134,7 +134,7 @@ public class RepeatedFieldBuilderV3<
    */
   private void ensureBuilders() {
     if (this.builders == null) {
-      this.builders = new ArrayList<SingleFieldBuilderV3<MType, BType, IType>>(messages.size());
+      this.builders = new ArrayList<SingleFieldBuilderV3Internal<MType, BType, IType>>(messages.size());
       for (int i = 0; i < messages.size(); i++) {
         builders.add(null);
       }
@@ -189,7 +189,7 @@ public class RepeatedFieldBuilderV3<
       return messages.get(index);
     }
 
-    SingleFieldBuilderV3<MType, BType, IType> builder = builders.get(index);
+    SingleFieldBuilderV3Internal<MType, BType, IType> builder = builders.get(index);
     if (builder == null) {
       // We don't have a builder -- return the current message.
       // This is the case where no builder was created for the entry at index,
@@ -210,10 +210,10 @@ public class RepeatedFieldBuilderV3<
    */
   public BType getBuilder(int index) {
     ensureBuilders();
-    SingleFieldBuilderV3<MType, BType, IType> builder = builders.get(index);
+    SingleFieldBuilderV3Internal<MType, BType, IType> builder = builders.get(index);
     if (builder == null) {
       MType message = messages.get(index);
-      builder = new SingleFieldBuilderV3<MType, BType, IType>(message, this, isClean);
+      builder = new SingleFieldBuilderV3Internal<MType, BType, IType>(message, this, isClean);
       builders.set(index, builder);
     }
     return builder.getBuilder();
@@ -235,7 +235,7 @@ public class RepeatedFieldBuilderV3<
       return (IType) messages.get(index);
     }
 
-    SingleFieldBuilderV3<MType, BType, IType> builder = builders.get(index);
+    SingleFieldBuilderV3Internal<MType, BType, IType> builder = builders.get(index);
     if (builder == null) {
       // We don't have a builder -- return the current message.
       // This is the case where no builder was created for the entry at index,
@@ -255,12 +255,12 @@ public class RepeatedFieldBuilderV3<
    * @return the builder
    */
   @CanIgnoreReturnValue
-  public RepeatedFieldBuilderV3<MType, BType, IType> setMessage(int index, MType message) {
+  public RepeatedFieldBuilderV3Internal<MType, BType, IType> setMessage(int index, MType message) {
     checkNotNull(message);
     ensureMutableMessageList();
     messages.set(index, message);
     if (builders != null) {
-      SingleFieldBuilderV3<MType, BType, IType> entry = builders.set(index, null);
+      SingleFieldBuilderV3Internal<MType, BType, IType> entry = builders.set(index, null);
       if (entry != null) {
         entry.dispose();
       }
@@ -277,7 +277,7 @@ public class RepeatedFieldBuilderV3<
    * @return the builder
    */
   @CanIgnoreReturnValue
-  public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(MType message) {
+  public RepeatedFieldBuilderV3Internal<MType, BType, IType> addMessage(MType message) {
     checkNotNull(message);
     ensureMutableMessageList();
     messages.add(message);
@@ -299,7 +299,7 @@ public class RepeatedFieldBuilderV3<
    * @return the builder
    */
   @CanIgnoreReturnValue
-  public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(int index, MType message) {
+  public RepeatedFieldBuilderV3Internal<MType, BType, IType> addMessage(int index, MType message) {
     checkNotNull(message);
     ensureMutableMessageList();
     messages.add(index, message);
@@ -319,7 +319,7 @@ public class RepeatedFieldBuilderV3<
    * @return the builder
    */
   @CanIgnoreReturnValue
-  public RepeatedFieldBuilderV3<MType, BType, IType> addAllMessages(
+  public RepeatedFieldBuilderV3Internal<MType, BType, IType> addAllMessages(
       Iterable<? extends MType> values) {
     for (final MType value : values) {
       checkNotNull(value);
@@ -358,8 +358,8 @@ public class RepeatedFieldBuilderV3<
   public BType addBuilder(MType message) {
     ensureMutableMessageList();
     ensureBuilders();
-    SingleFieldBuilderV3<MType, BType, IType> builder =
-        new SingleFieldBuilderV3<MType, BType, IType>(message, this, isClean);
+    SingleFieldBuilderV3Internal<MType, BType, IType> builder =
+        new SingleFieldBuilderV3Internal<MType, BType, IType>(message, this, isClean);
     messages.add(null);
     builders.add(builder);
     onChanged();
@@ -378,8 +378,8 @@ public class RepeatedFieldBuilderV3<
   public BType addBuilder(int index, MType message) {
     ensureMutableMessageList();
     ensureBuilders();
-    SingleFieldBuilderV3<MType, BType, IType> builder =
-        new SingleFieldBuilderV3<MType, BType, IType>(message, this, isClean);
+    SingleFieldBuilderV3Internal<MType, BType, IType> builder =
+        new SingleFieldBuilderV3Internal<MType, BType, IType>(message, this, isClean);
     messages.add(index, null);
     builders.add(index, builder);
     onChanged();
@@ -397,7 +397,7 @@ public class RepeatedFieldBuilderV3<
     ensureMutableMessageList();
     messages.remove(index);
     if (builders != null) {
-      SingleFieldBuilderV3<MType, BType, IType> entry = builders.remove(index);
+      SingleFieldBuilderV3Internal<MType, BType, IType> entry = builders.remove(index);
       if (entry != null) {
         entry.dispose();
       }
@@ -411,7 +411,7 @@ public class RepeatedFieldBuilderV3<
     messages = Collections.emptyList();
     isMessagesListMutable = false;
     if (builders != null) {
-      for (SingleFieldBuilderV3<MType, BType, IType> entry : builders) {
+      for (SingleFieldBuilderV3Internal<MType, BType, IType> entry : builders) {
         if (entry != null) {
           entry.dispose();
         }
@@ -443,7 +443,7 @@ public class RepeatedFieldBuilderV3<
       // of sync with their builders.
       for (int i = 0; i < messages.size(); i++) {
         Message message = messages.get(i);
-        SingleFieldBuilderV3<MType, BType, IType> builder = builders.get(i);
+        SingleFieldBuilderV3Internal<MType, BType, IType> builder = builders.get(i);
         if (builder != null) {
           if (builder.build() != message) {
             allMessagesInSync = false;
@@ -556,9 +556,9 @@ public class RepeatedFieldBuilderV3<
           IType extends MessageOrBuilder>
       extends AbstractList<MType> implements List<MType>, RandomAccess {
 
-    RepeatedFieldBuilderV3<MType, BType, IType> builder;
+    RepeatedFieldBuilderV3Internal<MType, BType, IType> builder;
 
-    MessageExternalList(RepeatedFieldBuilderV3<MType, BType, IType> builder) {
+    MessageExternalList(RepeatedFieldBuilderV3Internal<MType, BType, IType> builder) {
       this.builder = builder;
     }
 
@@ -590,9 +590,9 @@ public class RepeatedFieldBuilderV3<
           IType extends MessageOrBuilder>
       extends AbstractList<BType> implements List<BType>, RandomAccess {
 
-    RepeatedFieldBuilderV3<MType, BType, IType> builder;
+    RepeatedFieldBuilderV3Internal<MType, BType, IType> builder;
 
-    BuilderExternalList(RepeatedFieldBuilderV3<MType, BType, IType> builder) {
+    BuilderExternalList(RepeatedFieldBuilderV3Internal<MType, BType, IType> builder) {
       this.builder = builder;
     }
 
@@ -624,9 +624,9 @@ public class RepeatedFieldBuilderV3<
           IType extends MessageOrBuilder>
       extends AbstractList<IType> implements List<IType>, RandomAccess {
 
-    RepeatedFieldBuilderV3<MType, BType, IType> builder;
+    RepeatedFieldBuilderV3Internal<MType, BType, IType> builder;
 
-    MessageOrBuilderExternalList(RepeatedFieldBuilderV3<MType, BType, IType> builder) {
+    MessageOrBuilderExternalList(RepeatedFieldBuilderV3Internal<MType, BType, IType> builder) {
       this.builder = builder;
     }
 

--- a/protobuf-api/src/main/java/com/google/protobuf/SingleFieldBuilderV3Internal.java
+++ b/protobuf-api/src/main/java/com/google/protobuf/SingleFieldBuilderV3Internal.java
@@ -29,7 +29,7 @@ import static com.google.protobuf.Internal.checkNotNull;
  * @param <IType> the common interface for the message and the builder
  * @author jonp@google.com (Jon Perlow)
  */
-public class SingleFieldBuilderV3<
+class SingleFieldBuilderV3Internal<
         MType extends Message,
         BType extends Message.Builder,
         IType extends MessageOrBuilder>
@@ -53,7 +53,7 @@ public class SingleFieldBuilderV3<
   // to dispatch dirty invalidations. See AbstractMessage.BuilderListener.
   private boolean isClean;
 
-  public SingleFieldBuilderV3(MType message, Message.BuilderParent parent, boolean isClean) {
+  public SingleFieldBuilderV3Internal(MType message, Message.BuilderParent parent, boolean isClean) {
     this.message = checkNotNull(message);
     this.parent = parent;
     this.isClean = isClean;
@@ -134,7 +134,7 @@ public class SingleFieldBuilderV3<
    * @return the builder
    */
   @CanIgnoreReturnValue
-  public SingleFieldBuilderV3<MType, BType, IType> setMessage(MType message) {
+  public SingleFieldBuilderV3Internal<MType, BType, IType> setMessage(MType message) {
     this.message = checkNotNull(message);
     if (builder != null) {
 //      builder.dispose();
@@ -151,7 +151,7 @@ public class SingleFieldBuilderV3<
    * @return the builder
    */
   @CanIgnoreReturnValue
-  public SingleFieldBuilderV3<MType, BType, IType> mergeFrom(MType value) {
+  public SingleFieldBuilderV3Internal<MType, BType, IType> mergeFrom(MType value) {
     if (builder == null && message == message.getDefaultInstanceForType()) {
       message = value;
     } else {
@@ -168,7 +168,7 @@ public class SingleFieldBuilderV3<
    */
   @SuppressWarnings("unchecked")
   @CanIgnoreReturnValue
-  public SingleFieldBuilderV3<MType, BType, IType> clear() {
+  public SingleFieldBuilderV3Internal<MType, BType, IType> clear() {
     message =
         (MType)
             (message != null
@@ -203,6 +203,13 @@ public class SingleFieldBuilderV3<
     }
   }
 
+  static <T> T checkNotNull(T obj) {
+    if (obj == null) {
+      throw new NullPointerException();
+    }
+    return obj;
+  }
+  
   @Override
   public void markDirty() {
     onChanged();

--- a/protobuf-api/src/main/java/com/google/protobuf/Type.java
+++ b/protobuf-api/src/main/java/com/google/protobuf/Type.java
@@ -1087,8 +1087,8 @@ private static final long serialVersionUID = 0L;
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Field, com.google.protobuf.Field.Builder, com.google.protobuf.FieldOrBuilder> fieldsBuilder_;
+    private RepeatedFieldBuilderV3Internal<
+            Field, Field.Builder, FieldOrBuilder> fieldsBuilder_;
 
     /**
      * <pre>
@@ -1375,12 +1375,12 @@ private static final long serialVersionUID = 0L;
          getFieldsBuilderList() {
       return getFieldsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Field, com.google.protobuf.Field.Builder, com.google.protobuf.FieldOrBuilder> 
+    private RepeatedFieldBuilderV3Internal<
+            Field, Field.Builder, FieldOrBuilder>
         getFieldsFieldBuilder() {
       if (fieldsBuilder_ == null) {
-        fieldsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.protobuf.Field, com.google.protobuf.Field.Builder, com.google.protobuf.FieldOrBuilder>(
+        fieldsBuilder_ = new RepeatedFieldBuilderV3Internal<
+                    Field, Field.Builder, FieldOrBuilder>(
                 fields_,
                 ((bitField0_ & 0x00000002) != 0),
                 getParentForChildren(),
@@ -1546,8 +1546,8 @@ private static final long serialVersionUID = 0L;
        }
     }
 
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> optionsBuilder_;
+    private RepeatedFieldBuilderV3Internal<
+            Option, Option.Builder, OptionOrBuilder> optionsBuilder_;
 
     /**
      * <pre>
@@ -1834,12 +1834,12 @@ private static final long serialVersionUID = 0L;
          getOptionsBuilderList() {
       return getOptionsFieldBuilder().getBuilderList();
     }
-    private com.google.protobuf.RepeatedFieldBuilderV3<
-        com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder> 
+    private RepeatedFieldBuilderV3Internal<
+            Option, Option.Builder, OptionOrBuilder>
         getOptionsFieldBuilder() {
       if (optionsBuilder_ == null) {
-        optionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-            com.google.protobuf.Option, com.google.protobuf.Option.Builder, com.google.protobuf.OptionOrBuilder>(
+        optionsBuilder_ = new RepeatedFieldBuilderV3Internal<
+                    Option, Option.Builder, OptionOrBuilder>(
                 options_,
                 ((bitField0_ & 0x00000008) != 0),
                 getParentForChildren(),
@@ -1850,8 +1850,8 @@ private static final long serialVersionUID = 0L;
     }
 
     private com.google.protobuf.SourceContext sourceContext_;
-    private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder> sourceContextBuilder_;
+    private SingleFieldBuilderV3Internal<
+            SourceContext, SourceContext.Builder, SourceContextOrBuilder> sourceContextBuilder_;
     /**
      * <pre>
      * The source context.
@@ -1992,12 +1992,12 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.google.protobuf.SourceContext source_context = 5;</code>
      */
-    private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder> 
+    private SingleFieldBuilderV3Internal<
+            SourceContext, SourceContext.Builder, SourceContextOrBuilder>
         getSourceContextFieldBuilder() {
       if (sourceContextBuilder_ == null) {
-        sourceContextBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.SourceContext, com.google.protobuf.SourceContext.Builder, com.google.protobuf.SourceContextOrBuilder>(
+        sourceContextBuilder_ = new SingleFieldBuilderV3Internal<
+                    SourceContext, SourceContext.Builder, SourceContextOrBuilder>(
                 getSourceContext(),
                 getParentForChildren(),
                 isClean());

--- a/protobuf-api/src/main/java/com/google/protobuf/Value.java
+++ b/protobuf-api/src/main/java/com/google/protobuf/Value.java
@@ -1196,8 +1196,8 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.Struct, com.google.protobuf.Struct.Builder, com.google.protobuf.StructOrBuilder> structValueBuilder_;
+    private SingleFieldBuilderV3Internal<
+            Struct, Struct.Builder, StructOrBuilder> structValueBuilder_;
     /**
      * <pre>
      * Represents a structured value.
@@ -1355,15 +1355,15 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.google.protobuf.Struct struct_value = 5;</code>
      */
-    private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.Struct, com.google.protobuf.Struct.Builder, com.google.protobuf.StructOrBuilder> 
+    private SingleFieldBuilderV3Internal<
+            Struct, Struct.Builder, StructOrBuilder>
         getStructValueFieldBuilder() {
       if (structValueBuilder_ == null) {
         if (!(kindCase_ == 5)) {
           kind_ = com.google.protobuf.Struct.getDefaultInstance();
         }
-        structValueBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.Struct, com.google.protobuf.Struct.Builder, com.google.protobuf.StructOrBuilder>(
+        structValueBuilder_ = new SingleFieldBuilderV3Internal<
+                    Struct, Struct.Builder, StructOrBuilder>(
                 (com.google.protobuf.Struct) kind_,
                 getParentForChildren(),
                 isClean());
@@ -1374,8 +1374,8 @@ private static final long serialVersionUID = 0L;
       return structValueBuilder_;
     }
 
-    private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.ListValue, com.google.protobuf.ListValue.Builder, com.google.protobuf.ListValueOrBuilder> listValueBuilder_;
+    private SingleFieldBuilderV3Internal<
+            ListValue, ListValue.Builder, ListValueOrBuilder> listValueBuilder_;
     /**
      * <pre>
      * Represents a repeated `Value`.
@@ -1533,15 +1533,15 @@ private static final long serialVersionUID = 0L;
      *
      * <code>.google.protobuf.ListValue list_value = 6;</code>
      */
-    private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.ListValue, com.google.protobuf.ListValue.Builder, com.google.protobuf.ListValueOrBuilder> 
+    private SingleFieldBuilderV3Internal<
+            ListValue, ListValue.Builder, ListValueOrBuilder>
         getListValueFieldBuilder() {
       if (listValueBuilder_ == null) {
         if (!(kindCase_ == 6)) {
           kind_ = com.google.protobuf.ListValue.getDefaultInstance();
         }
-        listValueBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-            com.google.protobuf.ListValue, com.google.protobuf.ListValue.Builder, com.google.protobuf.ListValueOrBuilder>(
+        listValueBuilder_ = new SingleFieldBuilderV3Internal<
+                    ListValue, ListValue.Builder, ListValueOrBuilder>(
                 (com.google.protobuf.ListValue) kind_,
                 getParentForChildren(),
                 isClean());

--- a/protobuf-sdk/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
+++ b/protobuf-sdk/src/main/java/com/google/protobuf/RepeatedFieldBuilderV3.java
@@ -1,0 +1,652 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package com.google.protobuf;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.RandomAccess;
+
+/**
+ * {@code RepeatedFieldBuilderV3} implements a structure that a protocol message uses to hold a
+ * repeated field of other protocol messages. It supports the classical use case of adding immutable
+ * {@link Message}'s to the repeated field and is highly optimized around this (no extra memory
+ * allocations and sharing of immutable arrays). <br>
+ * It also supports the additional use case of adding a {@link Message.Builder} to the repeated
+ * field and deferring conversion of that {@code Builder} to an immutable {@code Message}. In this
+ * way, it's possible to maintain a tree of {@code Builder}'s that acts as a fully read/write data
+ * structure. <br>
+ * Logically, one can think of a tree of builders as converting the entire tree to messages when
+ * build is called on the root or when any method is called that desires a Message instead of a
+ * Builder. In terms of the implementation, the {@code SingleFieldBuilderV3} and {@code
+ * RepeatedFieldBuilderV3} classes cache messages that were created so that messages only need to be
+ * created when some change occurred in its builder or a builder for one of its descendants.
+ *
+ * @param <MType> the type of message for the field
+ * @param <BType> the type of builder for the field
+ * @param <IType> the common interface for the message and the builder
+ * @author jonp@google.com (Jon Perlow)
+ */
+public class RepeatedFieldBuilderV3<
+        MType extends AbstractMessage,
+        BType extends AbstractMessage.Builder,
+        IType extends MessageOrBuilder>
+    implements AbstractMessage.BuilderParent {
+
+  // Parent to send changes to.
+  private AbstractMessage.BuilderParent parent;
+
+  // List of messages. Never null. It may be immutable, in which case
+  // isMessagesListMutable will be false. See note below.
+  private List<MType> messages;
+
+  // Whether messages is an mutable array that can be modified.
+  private boolean isMessagesListMutable;
+
+  // List of builders. May be null, in which case, no nested builders were
+  // created. If not null, entries represent the builder for that index.
+  private List<SingleFieldBuilderV3<MType, BType, IType>> builders;
+
+  // Here are the invariants for messages and builders:
+  // 1. messages is never null and its count corresponds to the number of items
+  //    in the repeated field.
+  // 2. If builders is non-null, messages and builders MUST always
+  //    contain the same number of items.
+  // 3. Entries in either array can be null, but for any index, there MUST be
+  //    either a Message in messages or a builder in builders.
+  // 4. If the builder at an index is non-null, the builder is
+  //    authoritative. This is the case where a Builder was set on the index.
+  //    Any message in the messages array MUST be ignored.
+  // t. If the builder at an index is null, the message in the messages
+  //    list is authoritative. This is the case where a Message (not a Builder)
+  //    was set directly for an index.
+
+  // Indicates that we've built a message and so we are now obligated
+  // to dispatch dirty invalidations. See AbstractMessage.BuilderListener.
+  private boolean isClean;
+
+  // A view of this builder that exposes a List interface of messages. This is
+  // initialized on demand. This is fully backed by this object and all changes
+  // are reflected in it. Access to any item converts it to a message if it
+  // was a builder.
+  private MessageExternalList<MType, BType, IType> externalMessageList;
+
+  // A view of this builder that exposes a List interface of builders. This is
+  // initialized on demand. This is fully backed by this object and all changes
+  // are reflected in it. Access to any item converts it to a builder if it
+  // was a message.
+  private BuilderExternalList<MType, BType, IType> externalBuilderList;
+
+  // A view of this builder that exposes a List interface of the interface
+  // implemented by messages and builders. This is initialized on demand. This
+  // is fully backed by this object and all changes are reflected in it.
+  // Access to any item returns either a builder or message depending on
+  // what is most efficient.
+  private MessageOrBuilderExternalList<MType, BType, IType> externalMessageOrBuilderList;
+
+  /**
+   * Constructs a new builder with an empty list of messages.
+   *
+   * @param messages the current list of messages
+   * @param isMessagesListMutable Whether the messages list is mutable
+   * @param parent a listener to notify of changes
+   * @param isClean whether the builder is initially marked clean
+   */
+  public RepeatedFieldBuilderV3(
+      List<MType> messages,
+      boolean isMessagesListMutable,
+      AbstractMessage.BuilderParent parent,
+      boolean isClean) {
+    this.messages = messages;
+    this.isMessagesListMutable = isMessagesListMutable;
+    this.parent = parent;
+    this.isClean = isClean;
+  }
+
+  public void dispose() {
+    // Null out parent so we stop sending it invalidations.
+    parent = null;
+  }
+
+  /**
+   * Ensures that the list of messages is mutable so it can be updated. If it's immutable, a copy is
+   * made.
+   */
+  private void ensureMutableMessageList() {
+    if (!isMessagesListMutable) {
+      messages = new ArrayList<MType>(messages);
+      isMessagesListMutable = true;
+    }
+  }
+
+  /**
+   * Ensures that the list of builders is not null. If it's null, the list is created and
+   * initialized to be the same size as the messages list with null entries.
+   */
+  private void ensureBuilders() {
+    if (this.builders == null) {
+      this.builders = new ArrayList<SingleFieldBuilderV3<MType, BType, IType>>(messages.size());
+      for (int i = 0; i < messages.size(); i++) {
+        builders.add(null);
+      }
+    }
+  }
+
+  /**
+   * Gets the count of items in the list.
+   *
+   * @return the count of items in the list.
+   */
+  public int getCount() {
+    return messages.size();
+  }
+
+  /**
+   * Gets whether the list is empty.
+   *
+   * @return whether the list is empty
+   */
+  public boolean isEmpty() {
+    return messages.isEmpty();
+  }
+
+  /**
+   * Get the message at the specified index. If the message is currently stored as a {@code
+   * Builder}, it is converted to a {@code Message} by calling {@link Message.Builder#buildPartial}
+   * on it.
+   *
+   * @param index the index of the message to get
+   * @return the message for the specified index
+   */
+  public MType getMessage(int index) {
+    return getMessage(index, false);
+  }
+
+  /**
+   * Get the message at the specified index. If the message is currently stored as a {@code
+   * Builder}, it is converted to a {@code Message} by calling {@link Message.Builder#buildPartial}
+   * on it.
+   *
+   * @param index the index of the message to get
+   * @param forBuild this is being called for build so we want to make sure we
+   *     SingleFieldBuilderV3.build to send dirty invalidations
+   * @return the message for the specified index
+   */
+  private MType getMessage(int index, boolean forBuild) {
+    if (this.builders == null) {
+      // We don't have any builders -- return the current Message.
+      // This is the case where no builder was created, so we MUST have a
+      // Message.
+      return messages.get(index);
+    }
+
+    SingleFieldBuilderV3<MType, BType, IType> builder = builders.get(index);
+    if (builder == null) {
+      // We don't have a builder -- return the current message.
+      // This is the case where no builder was created for the entry at index,
+      // so we MUST have a message.
+      return messages.get(index);
+
+    } else {
+      return forBuild ? builder.build() : builder.getMessage();
+    }
+  }
+
+  /**
+   * Gets a builder for the specified index. If no builder has been created for that index, a
+   * builder is created on demand by calling {@link Message#toBuilder}.
+   *
+   * @param index the index of the message to get
+   * @return The builder for that index
+   */
+  public BType getBuilder(int index) {
+    ensureBuilders();
+    SingleFieldBuilderV3<MType, BType, IType> builder = builders.get(index);
+    if (builder == null) {
+      MType message = messages.get(index);
+      builder = new SingleFieldBuilderV3<MType, BType, IType>(message, this, isClean);
+      builders.set(index, builder);
+    }
+    return builder.getBuilder();
+  }
+
+  /**
+   * Gets the base class interface for the specified index. This may either be a builder or a
+   * message. It will return whatever is more efficient.
+   *
+   * @param index the index of the message to get
+   * @return the message or builder for the index as the base class interface
+   */
+  @SuppressWarnings("unchecked")
+  public IType getMessageOrBuilder(int index) {
+    if (this.builders == null) {
+      // We don't have any builders -- return the current Message.
+      // This is the case where no builder was created, so we MUST have a
+      // Message.
+      return (IType) messages.get(index);
+    }
+
+    SingleFieldBuilderV3<MType, BType, IType> builder = builders.get(index);
+    if (builder == null) {
+      // We don't have a builder -- return the current message.
+      // This is the case where no builder was created for the entry at index,
+      // so we MUST have a message.
+      return (IType) messages.get(index);
+
+    } else {
+      return builder.getMessageOrBuilder();
+    }
+  }
+
+  /**
+   * Sets a message at the specified index replacing the existing item at that index.
+   *
+   * @param index the index to set.
+   * @param message the message to set
+   * @return the builder
+   */
+  @CanIgnoreReturnValue
+  public RepeatedFieldBuilderV3<MType, BType, IType> setMessage(int index, MType message) {
+    checkNotNull(message);
+    ensureMutableMessageList();
+    messages.set(index, message);
+    if (builders != null) {
+      SingleFieldBuilderV3<MType, BType, IType> entry = builders.set(index, null);
+      if (entry != null) {
+        entry.dispose();
+      }
+    }
+    onChanged();
+    incrementModCounts();
+    return this;
+  }
+
+  /**
+   * Appends the specified element to the end of this list.
+   *
+   * @param message the message to add
+   * @return the builder
+   */
+  @CanIgnoreReturnValue
+  public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(MType message) {
+    checkNotNull(message);
+    ensureMutableMessageList();
+    messages.add(message);
+    if (builders != null) {
+      builders.add(null);
+    }
+    onChanged();
+    incrementModCounts();
+    return this;
+  }
+
+  /**
+   * Inserts the specified message at the specified position in this list. Shifts the element
+   * currently at that position (if any) and any subsequent elements to the right (adds one to their
+   * indices).
+   *
+   * @param index the index at which to insert the message
+   * @param message the message to add
+   * @return the builder
+   */
+  @CanIgnoreReturnValue
+  public RepeatedFieldBuilderV3<MType, BType, IType> addMessage(int index, MType message) {
+    checkNotNull(message);
+    ensureMutableMessageList();
+    messages.add(index, message);
+    if (builders != null) {
+      builders.add(index, null);
+    }
+    onChanged();
+    incrementModCounts();
+    return this;
+  }
+
+  /**
+   * Appends all of the messages in the specified collection to the end of this list, in the order
+   * that they are returned by the specified collection's iterator.
+   *
+   * @param values the messages to add
+   * @return the builder
+   */
+  @CanIgnoreReturnValue
+  public RepeatedFieldBuilderV3<MType, BType, IType> addAllMessages(
+      Iterable<? extends MType> values) {
+    for (final MType value : values) {
+      checkNotNull(value);
+    }
+
+    // If we can inspect the size, we can more efficiently add messages.
+    int size = -1;
+    if (values instanceof Collection) {
+      final Collection<?> collection = (Collection<?>) values;
+      if (collection.isEmpty()) {
+        return this;
+      }
+      size = collection.size();
+    }
+    ensureMutableMessageList();
+
+    if (size >= 0 && messages instanceof ArrayList) {
+      ((ArrayList<MType>) messages).ensureCapacity(messages.size() + size);
+    }
+
+    for (MType value : values) {
+      addMessage(value);
+    }
+
+    onChanged();
+    incrementModCounts();
+    return this;
+  }
+
+  /**
+   * Appends a new builder to the end of this list and returns the builder.
+   *
+   * @param message the message to add which is the basis of the builder
+   * @return the new builder
+   */
+  public BType addBuilder(MType message) {
+    ensureMutableMessageList();
+    ensureBuilders();
+    SingleFieldBuilderV3<MType, BType, IType> builder =
+        new SingleFieldBuilderV3<MType, BType, IType>(message, this, isClean);
+    messages.add(null);
+    builders.add(builder);
+    onChanged();
+    incrementModCounts();
+    return builder.getBuilder();
+  }
+
+  static <T> T checkNotNull(T obj) {
+    if (obj == null) {
+      throw new NullPointerException();
+    }
+    return obj;
+  }
+
+  /**
+   * Inserts a new builder at the specified position in this list. Shifts the element currently at
+   * that position (if any) and any subsequent elements to the right (adds one to their indices).
+   *
+   * @param index the index at which to insert the builder
+   * @param message the message to add which is the basis of the builder
+   * @return the builder
+   */
+  public BType addBuilder(int index, MType message) {
+    ensureMutableMessageList();
+    ensureBuilders();
+    SingleFieldBuilderV3<MType, BType, IType> builder =
+        new SingleFieldBuilderV3<MType, BType, IType>(message, this, isClean);
+    messages.add(index, null);
+    builders.add(index, builder);
+    onChanged();
+    incrementModCounts();
+    return builder.getBuilder();
+  }
+
+  /**
+   * Removes the element at the specified position in this list. Shifts any subsequent elements to
+   * the left (subtracts one from their indices).
+   *
+   * @param index the index at which to remove the message
+   */
+  public void remove(int index) {
+    ensureMutableMessageList();
+    messages.remove(index);
+    if (builders != null) {
+      SingleFieldBuilderV3<MType, BType, IType> entry = builders.remove(index);
+      if (entry != null) {
+        entry.dispose();
+      }
+    }
+    onChanged();
+    incrementModCounts();
+  }
+
+  /** Removes all of the elements from this list. The list will be empty after this call returns. */
+  public void clear() {
+    messages = Collections.emptyList();
+    isMessagesListMutable = false;
+    if (builders != null) {
+      for (SingleFieldBuilderV3<MType, BType, IType> entry : builders) {
+        if (entry != null) {
+          entry.dispose();
+        }
+      }
+      builders = null;
+    }
+    onChanged();
+    incrementModCounts();
+  }
+
+  /**
+   * Builds the list of messages from the builder and returns them.
+   *
+   * @return an immutable list of messages
+   */
+  public List<MType> build() {
+    // Now that build has been called, we are required to dispatch
+    // invalidations.
+    isClean = true;
+
+    if (!isMessagesListMutable && builders == null) {
+      // We still have an immutable list and we never created a builder.
+      return messages;
+    }
+
+    boolean allMessagesInSync = true;
+    if (!isMessagesListMutable) {
+      // We still have an immutable list. Let's see if any of them are out
+      // of sync with their builders.
+      for (int i = 0; i < messages.size(); i++) {
+        Message message = messages.get(i);
+        SingleFieldBuilderV3<MType, BType, IType> builder = builders.get(i);
+        if (builder != null) {
+          if (builder.build() != message) {
+            allMessagesInSync = false;
+            break;
+          }
+        }
+      }
+      if (allMessagesInSync) {
+        // Immutable list is still in sync.
+        return messages;
+      }
+    }
+
+    // Need to make sure messages is up to date
+    ensureMutableMessageList();
+    for (int i = 0; i < messages.size(); i++) {
+      messages.set(i, getMessage(i, true));
+    }
+
+    // We're going to return our list as immutable so we mark that we can
+    // no longer update it.
+    messages = Collections.unmodifiableList(messages);
+    isMessagesListMutable = false;
+    return messages;
+  }
+
+  /**
+   * Gets a view of the builder as a list of messages. The returned list is live and will reflect
+   * any changes to the underlying builder.
+   *
+   * @return the messages in the list
+   */
+  public List<MType> getMessageList() {
+    if (externalMessageList == null) {
+      externalMessageList = new MessageExternalList<MType, BType, IType>(this);
+    }
+    return externalMessageList;
+  }
+
+  /**
+   * Gets a view of the builder as a list of builders. This returned list is live and will reflect
+   * any changes to the underlying builder.
+   *
+   * @return the builders in the list
+   */
+  public List<BType> getBuilderList() {
+    if (externalBuilderList == null) {
+      externalBuilderList = new BuilderExternalList<MType, BType, IType>(this);
+    }
+    return externalBuilderList;
+  }
+
+  /**
+   * Gets a view of the builder as a list of MessageOrBuilders. This returned list is live and will
+   * reflect any changes to the underlying builder.
+   *
+   * @return the builders in the list
+   */
+  public List<IType> getMessageOrBuilderList() {
+    if (externalMessageOrBuilderList == null) {
+      externalMessageOrBuilderList = new MessageOrBuilderExternalList<MType, BType, IType>(this);
+    }
+    return externalMessageOrBuilderList;
+  }
+
+  /**
+   * Called when a the builder or one of its nested children has changed and any parent should be
+   * notified of its invalidation.
+   */
+  private void onChanged() {
+    if (isClean && parent != null) {
+      parent.markDirty();
+
+      // Don't keep dispatching invalidations until build is called again.
+      isClean = false;
+    }
+  }
+
+  @Override
+  public void markDirty() {
+    onChanged();
+  }
+
+  /**
+   * Increments the mod counts so that an ConcurrentModificationException can be thrown if calling
+   * code tries to modify the builder while its iterating the list.
+   */
+  private void incrementModCounts() {
+    if (externalMessageList != null) {
+      externalMessageList.incrementModCount();
+    }
+    if (externalBuilderList != null) {
+      externalBuilderList.incrementModCount();
+    }
+    if (externalMessageOrBuilderList != null) {
+      externalMessageOrBuilderList.incrementModCount();
+    }
+  }
+
+  /**
+   * Provides a live view of the builder as a list of messages.
+   *
+   * @param <MType> the type of message for the field
+   * @param <BType> the type of builder for the field
+   * @param <IType> the common interface for the message and the builder
+   */
+  private static class MessageExternalList<
+          MType extends AbstractMessage,
+          BType extends AbstractMessage.Builder,
+          IType extends MessageOrBuilder>
+      extends AbstractList<MType> implements List<MType>, RandomAccess {
+
+    RepeatedFieldBuilderV3<MType, BType, IType> builder;
+
+    MessageExternalList(RepeatedFieldBuilderV3<MType, BType, IType> builder) {
+      this.builder = builder;
+    }
+
+    @Override
+    public int size() {
+      return this.builder.getCount();
+    }
+
+    @Override
+    public MType get(int index) {
+      return builder.getMessage(index);
+    }
+
+    void incrementModCount() {
+      modCount++;
+    }
+  }
+
+  /**
+   * Provides a live view of the builder as a list of builders.
+   *
+   * @param <MType> the type of message for the field
+   * @param <BType> the type of builder for the field
+   * @param <IType> the common interface for the message and the builder
+   */
+  private static class BuilderExternalList<
+          MType extends AbstractMessage,
+          BType extends AbstractMessage.Builder,
+          IType extends MessageOrBuilder>
+      extends AbstractList<BType> implements List<BType>, RandomAccess {
+
+    RepeatedFieldBuilderV3<MType, BType, IType> builder;
+
+    BuilderExternalList(RepeatedFieldBuilderV3<MType, BType, IType> builder) {
+      this.builder = builder;
+    }
+
+    @Override
+    public int size() {
+      return this.builder.getCount();
+    }
+
+    @Override
+    public BType get(int index) {
+      return builder.getBuilder(index);
+    }
+
+    void incrementModCount() {
+      modCount++;
+    }
+  }
+
+  /**
+   * Provides a live view of the builder as a list of builders.
+   *
+   * @param <MType> the type of message for the field
+   * @param <BType> the type of builder for the field
+   * @param <IType> the common interface for the message and the builder
+   */
+  private static class MessageOrBuilderExternalList<
+          MType extends AbstractMessage,
+          BType extends AbstractMessage.Builder,
+          IType extends MessageOrBuilder>
+      extends AbstractList<IType> implements List<IType>, RandomAccess {
+
+    RepeatedFieldBuilderV3<MType, BType, IType> builder;
+
+    MessageOrBuilderExternalList(RepeatedFieldBuilderV3<MType, BType, IType> builder) {
+      this.builder = builder;
+    }
+
+    @Override
+    public int size() {
+      return this.builder.getCount();
+    }
+
+    @Override
+    public IType get(int index) {
+      return builder.getMessageOrBuilder(index);
+    }
+
+    void incrementModCount() {
+      modCount++;
+    }
+  }
+}

--- a/protobuf-sdk/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
+++ b/protobuf-sdk/src/main/java/com/google/protobuf/SingleFieldBuilderV3.java
@@ -1,0 +1,215 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package com.google.protobuf;
+
+/**
+ * {@code SingleFieldBuilderV3} implements a structure that a protocol message uses to hold a single
+ * field of another protocol message. It supports the classical use case of setting an immutable
+ * {@link Message} as the value of the field and is highly optimized around this.
+ *
+ * <p>It also supports the additional use case of setting a {@link Message.Builder} as the field and
+ * deferring conversion of that {@code Builder} to an immutable {@code Message}. In this way, it's
+ * possible to maintain a tree of {@code Builder}'s that acts as a fully read/write data structure.
+ * <br>
+ * Logically, one can think of a tree of builders as converting the entire tree to messages when
+ * build is called on the root or when any method is called that desires a Message instead of a
+ * Builder. In terms of the implementation, the {@code SingleFieldBuilderV3} and {@code
+ * RepeatedFieldBuilderV3} classes cache messages that were created so that messages only need to be
+ * created when some change occurred in its builder or a builder for one of its descendants.
+ *
+ * @param <MType> the type of message for the field
+ * @param <BType> the type of builder for the field
+ * @param <IType> the common interface for the message and the builder
+ * @author jonp@google.com (Jon Perlow)
+ */
+public class SingleFieldBuilderV3<
+        MType extends AbstractMessage,
+        BType extends AbstractMessage.Builder,
+        IType extends MessageOrBuilder>
+    implements AbstractMessage.BuilderParent {
+
+  // Parent to send changes to.
+  private AbstractMessage.BuilderParent parent;
+
+  // Invariant: one of builder or message fields must be non-null.
+
+  // If set, this is the case where we are backed by a builder. In this case,
+  // message field represents a cached message for the builder (or null if
+  // there is no cached message).
+  private BType builder;
+
+  // If builder is non-null, this represents a cached message from the builder.
+  // If builder is null, this is the authoritative message for the field.
+  private MType message;
+
+  // Indicates that we've built a message and so we are now obligated
+  // to dispatch dirty invalidations. See AbstractMessage.BuilderListener.
+  private boolean isClean;
+
+  public SingleFieldBuilderV3(MType message, AbstractMessage.BuilderParent parent, boolean isClean) {
+    this.message = checkNotNull(message);
+    this.parent = parent;
+    this.isClean = isClean;
+  }
+
+  static <T> T checkNotNull(T obj) {
+    if (obj == null) {
+      throw new NullPointerException();
+    }
+    return obj;
+  }
+
+  public void dispose() {
+    // Null out parent so we stop sending it invalidations.
+    parent = null;
+  }
+
+  /**
+   * Get the message for the field. If the message is currently stored as a {@code Builder}, it is
+   * converted to a {@code Message} by calling {@link Message.Builder#buildPartial} on it. If no
+   * message has been set, returns the default instance of the message.
+   *
+   * @return the message for the field
+   */
+  @SuppressWarnings("unchecked")
+  public MType getMessage() {
+    if (message == null) {
+      // If message is null, the invariant is that we must be have a builder.
+      message = (MType) builder.buildPartial();
+    }
+    return message;
+  }
+
+  /**
+   * Builds the message and returns it.
+   *
+   * @return the message
+   */
+  public MType build() {
+    // Now that build has been called, we are required to dispatch
+    // invalidations.
+    isClean = true;
+    return getMessage();
+  }
+
+  /**
+   * Gets a builder for the field. If no builder has been created yet, a builder is created on
+   * demand by calling {@link Message#toBuilder}.
+   *
+   * @return The builder for the field
+   */
+  @SuppressWarnings("unchecked")
+  public BType getBuilder() {
+    if (builder == null) {
+      // builder.mergeFrom() on a fresh builder
+      // does not create any sub-objects with independent clean/dirty states,
+      // therefore setting the builder itself to clean without actually calling
+      // build() cannot break any invariants.
+      builder = (BType) message.newBuilderForType(this);
+      builder.mergeFrom(message); // no-op if message is the default message
+      builder.markClean();
+    }
+    return builder;
+  }
+
+  /**
+   * Gets the base class interface for the field. This may either be a builder or a message. It will
+   * return whatever is more efficient.
+   *
+   * @return the message or builder for the field as the base class interface
+   */
+  @SuppressWarnings("unchecked")
+  public IType getMessageOrBuilder() {
+    if (builder != null) {
+      return (IType) builder;
+    } else {
+      return (IType) message;
+    }
+  }
+
+  /**
+   * Sets a message for the field replacing any existing value.
+   *
+   * @param message the message to set
+   * @return the builder
+   */
+  @CanIgnoreReturnValue
+  public SingleFieldBuilderV3<MType, BType, IType> setMessage(MType message) {
+    this.message = checkNotNull(message);
+    if (builder != null) {
+      builder.dispose();
+      builder = null;
+    }
+    onChanged();
+    return this;
+  }
+
+  /**
+   * Merges the field from another field.
+   *
+   * @param value the value to merge from
+   * @return the builder
+   */
+  @CanIgnoreReturnValue
+  public SingleFieldBuilderV3<MType, BType, IType> mergeFrom(MType value) {
+    if (builder == null && message == message.getDefaultInstanceForType()) {
+      message = value;
+    } else {
+      getBuilder().mergeFrom(value);
+    }
+    onChanged();
+    return this;
+  }
+
+  /**
+   * Clears the value of the field.
+   *
+   * @return the builder
+   */
+  @SuppressWarnings("unchecked")
+  @CanIgnoreReturnValue
+  public SingleFieldBuilderV3<MType, BType, IType> clear() {
+    message =
+        (MType)
+            (message != null
+                ? message.getDefaultInstanceForType()
+                : builder.getDefaultInstanceForType());
+    if (builder != null) {
+      builder.dispose();
+      builder = null;
+    }
+    onChanged();
+    // After clearing, parent is dirty, but this field builder is now clean and any changes should
+    // trickle up.
+    isClean = true;
+    return this;
+  }
+
+  /**
+   * Called when a the builder or one of its nested children has changed and any parent should be
+   * notified of its invalidation.
+   */
+  private void onChanged() {
+    // If builder is null, this is the case where onChanged is being called
+    // from setMessage or clear.
+    if (builder != null) {
+      message = null;
+    }
+    if (isClean && parent != null) {
+      parent.markDirty();
+
+      // Don't keep dispatching invalidations until build is called again.
+      isClean = false;
+    }
+  }
+
+  @Override
+  public void markDirty() {
+    onChanged();
+  }
+}

--- a/protobuf-sdk/src/main/java/com/google/protobuf/compiler/PluginProtos.java
+++ b/protobuf-sdk/src/main/java/com/google/protobuf/compiler/PluginProtos.java
@@ -4,6 +4,8 @@
 // Protobuf Java Version: 3.25.5
 package com.google.protobuf.compiler;
 
+import java.util.Map;
+
 public final class PluginProtos {
   private PluginProtos() {}
   public static void registerAllExtensions(
@@ -2549,7 +2551,7 @@ public final class PluginProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
+      private com.google.protobuf.compiler.RepeatedFieldBuilderV3Internal<
           com.google.protobuf.DescriptorProtos.FileDescriptorProto, com.google.protobuf.DescriptorProtos.FileDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FileDescriptorProtoOrBuilder> protoFileBuilder_;
 
       /**
@@ -3161,11 +3163,11 @@ public final class PluginProtos {
            getProtoFileBuilderList() {
         return getProtoFileFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
+      private com.google.protobuf.compiler.RepeatedFieldBuilderV3Internal<
           com.google.protobuf.DescriptorProtos.FileDescriptorProto, com.google.protobuf.DescriptorProtos.FileDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FileDescriptorProtoOrBuilder> 
           getProtoFileFieldBuilder() {
         if (protoFileBuilder_ == null) {
-          protoFileBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+          protoFileBuilder_ = new com.google.protobuf.compiler.RepeatedFieldBuilderV3Internal<
               com.google.protobuf.DescriptorProtos.FileDescriptorProto, com.google.protobuf.DescriptorProtos.FileDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FileDescriptorProtoOrBuilder>(
                   protoFile_,
                   ((bitField0_ & 0x00000004) != 0),
@@ -3185,7 +3187,7 @@ public final class PluginProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
+      private com.google.protobuf.compiler.RepeatedFieldBuilderV3Internal<
           com.google.protobuf.DescriptorProtos.FileDescriptorProto, com.google.protobuf.DescriptorProtos.FileDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FileDescriptorProtoOrBuilder> sourceFileDescriptorsBuilder_;
 
       /**
@@ -3509,11 +3511,11 @@ public final class PluginProtos {
            getSourceFileDescriptorsBuilderList() {
         return getSourceFileDescriptorsFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
+      private com.google.protobuf.compiler.RepeatedFieldBuilderV3Internal<
           com.google.protobuf.DescriptorProtos.FileDescriptorProto, com.google.protobuf.DescriptorProtos.FileDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FileDescriptorProtoOrBuilder> 
           getSourceFileDescriptorsFieldBuilder() {
         if (sourceFileDescriptorsBuilder_ == null) {
-          sourceFileDescriptorsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+          sourceFileDescriptorsBuilder_ = new com.google.protobuf.compiler.RepeatedFieldBuilderV3Internal<
               com.google.protobuf.DescriptorProtos.FileDescriptorProto, com.google.protobuf.DescriptorProtos.FileDescriptorProto.Builder, com.google.protobuf.DescriptorProtos.FileDescriptorProtoOrBuilder>(
                   sourceFileDescriptors_,
                   ((bitField0_ & 0x00000008) != 0),
@@ -3525,7 +3527,7 @@ public final class PluginProtos {
       }
 
       private com.google.protobuf.compiler.PluginProtos.Version compilerVersion_;
-      private com.google.protobuf.SingleFieldBuilderV3<
+      private com.google.protobuf.compiler.SingleFieldBuilderV3Internal<
           com.google.protobuf.compiler.PluginProtos.Version, com.google.protobuf.compiler.PluginProtos.Version.Builder, com.google.protobuf.compiler.PluginProtos.VersionOrBuilder> compilerVersionBuilder_;
       /**
        * <pre>
@@ -3667,11 +3669,11 @@ public final class PluginProtos {
        *
        * <code>optional .google.protobuf.compiler.Version compiler_version = 3;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
+      private com.google.protobuf.compiler.SingleFieldBuilderV3Internal<
           com.google.protobuf.compiler.PluginProtos.Version, com.google.protobuf.compiler.PluginProtos.Version.Builder, com.google.protobuf.compiler.PluginProtos.VersionOrBuilder> 
           getCompilerVersionFieldBuilder() {
         if (compilerVersionBuilder_ == null) {
-          compilerVersionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+          compilerVersionBuilder_ = new com.google.protobuf.compiler.SingleFieldBuilderV3Internal<
               com.google.protobuf.compiler.PluginProtos.Version, com.google.protobuf.compiler.PluginProtos.Version.Builder, com.google.protobuf.compiler.PluginProtos.VersionOrBuilder>(
                   getCompilerVersion(),
                   getParentForChildren(),
@@ -5743,7 +5745,7 @@ public final class PluginProtos {
         }
 
         private com.google.protobuf.DescriptorProtos.GeneratedCodeInfo generatedCodeInfo_;
-        private com.google.protobuf.SingleFieldBuilderV3<
+        private com.google.protobuf.compiler.SingleFieldBuilderV3Internal<
             com.google.protobuf.DescriptorProtos.GeneratedCodeInfo, com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.Builder, com.google.protobuf.DescriptorProtos.GeneratedCodeInfoOrBuilder> generatedCodeInfoBuilder_;
         /**
          * <pre>
@@ -5903,11 +5905,11 @@ public final class PluginProtos {
          *
          * <code>optional .google.protobuf.GeneratedCodeInfo generated_code_info = 16;</code>
          */
-        private com.google.protobuf.SingleFieldBuilderV3<
+        private com.google.protobuf.compiler.SingleFieldBuilderV3Internal<
             com.google.protobuf.DescriptorProtos.GeneratedCodeInfo, com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.Builder, com.google.protobuf.DescriptorProtos.GeneratedCodeInfoOrBuilder> 
             getGeneratedCodeInfoFieldBuilder() {
           if (generatedCodeInfoBuilder_ == null) {
-            generatedCodeInfoBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+            generatedCodeInfoBuilder_ = new com.google.protobuf.compiler.SingleFieldBuilderV3Internal<
                 com.google.protobuf.DescriptorProtos.GeneratedCodeInfo, com.google.protobuf.DescriptorProtos.GeneratedCodeInfo.Builder, com.google.protobuf.DescriptorProtos.GeneratedCodeInfoOrBuilder>(
                     getGeneratedCodeInfo(),
                     getParentForChildren(),
@@ -7048,7 +7050,7 @@ public final class PluginProtos {
          }
       }
 
-      private com.google.protobuf.RepeatedFieldBuilderV3<
+      private com.google.protobuf.compiler.RepeatedFieldBuilderV3Internal<
           com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File, com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File.Builder, com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.FileOrBuilder> fileBuilder_;
 
       /**
@@ -7264,11 +7266,11 @@ public final class PluginProtos {
            getFileBuilderList() {
         return getFileFieldBuilder().getBuilderList();
       }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
+      private com.google.protobuf.compiler.RepeatedFieldBuilderV3Internal<
           com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File, com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File.Builder, com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.FileOrBuilder> 
           getFileFieldBuilder() {
         if (fileBuilder_ == null) {
-          fileBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+          fileBuilder_ = new com.google.protobuf.compiler.RepeatedFieldBuilderV3Internal<
               com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File, com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File.Builder, com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.FileOrBuilder>(
                   file_,
                   ((bitField0_ & 0x00000010) != 0),

--- a/protobuf-sdk/src/main/java/com/google/protobuf/compiler/RepeatedFieldBuilderV3Internal.java
+++ b/protobuf-sdk/src/main/java/com/google/protobuf/compiler/RepeatedFieldBuilderV3Internal.java
@@ -1,0 +1,656 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package com.google.protobuf.compiler;
+
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.RandomAccess;
+
+
+/**
+ * {@code RepeatedFieldBuilderV3} implements a structure that a protocol message uses to hold a
+ * repeated field of other protocol messages. It supports the classical use case of adding immutable
+ * {@link Message}'s to the repeated field and is highly optimized around this (no extra memory
+ * allocations and sharing of immutable arrays). <br>
+ * It also supports the additional use case of adding a {@link Message.Builder} to the repeated
+ * field and deferring conversion of that {@code Builder} to an immutable {@code Message}. In this
+ * way, it's possible to maintain a tree of {@code Builder}'s that acts as a fully read/write data
+ * structure. <br>
+ * Logically, one can think of a tree of builders as converting the entire tree to messages when
+ * build is called on the root or when any method is called that desires a Message instead of a
+ * Builder. In terms of the implementation, the {@code SingleFieldBuilderV3} and {@code
+ * RepeatedFieldBuilderV3} classes cache messages that were created so that messages only need to be
+ * created when some change occurred in its builder or a builder for one of its descendants.
+ *
+ * @param <MType> the type of message for the field
+ * @param <BType> the type of builder for the field
+ * @param <IType> the common interface for the message and the builder
+ * @author jonp@google.com (Jon Perlow)
+ */
+class RepeatedFieldBuilderV3Internal<
+        MType extends Message,
+        BType extends Message.Builder,
+        IType extends MessageOrBuilder>
+    implements Message.BuilderParent {
+
+  // Parent to send changes to.
+  private Message.BuilderParent parent;
+
+  // List of messages. Never null. It may be immutable, in which case
+  // isMessagesListMutable will be false. See note below.
+  private List<MType> messages;
+
+  // Whether messages is an mutable array that can be modified.
+  private boolean isMessagesListMutable;
+
+  // List of builders. May be null, in which case, no nested builders were
+  // created. If not null, entries represent the builder for that index.
+  private List<SingleFieldBuilderV3Internal<MType, BType, IType>> builders;
+
+  // Here are the invariants for messages and builders:
+  // 1. messages is never null and its count corresponds to the number of items
+  //    in the repeated field.
+  // 2. If builders is non-null, messages and builders MUST always
+  //    contain the same number of items.
+  // 3. Entries in either array can be null, but for any index, there MUST be
+  //    either a Message in messages or a builder in builders.
+  // 4. If the builder at an index is non-null, the builder is
+  //    authoritative. This is the case where a Builder was set on the index.
+  //    Any message in the messages array MUST be ignored.
+  // t. If the builder at an index is null, the message in the messages
+  //    list is authoritative. This is the case where a Message (not a Builder)
+  //    was set directly for an index.
+
+  // Indicates that we've built a message and so we are now obligated
+  // to dispatch dirty invalidations. See AbstractMessage.BuilderListener.
+  private boolean isClean;
+
+  // A view of this builder that exposes a List interface of messages. This is
+  // initialized on demand. This is fully backed by this object and all changes
+  // are reflected in it. Access to any item converts it to a message if it
+  // was a builder.
+  private MessageExternalList<MType, BType, IType> externalMessageList;
+
+  // A view of this builder that exposes a List interface of builders. This is
+  // initialized on demand. This is fully backed by this object and all changes
+  // are reflected in it. Access to any item converts it to a builder if it
+  // was a message.
+  private BuilderExternalList<MType, BType, IType> externalBuilderList;
+
+  // A view of this builder that exposes a List interface of the interface
+  // implemented by messages and builders. This is initialized on demand. This
+  // is fully backed by this object and all changes are reflected in it.
+  // Access to any item returns either a builder or message depending on
+  // what is most efficient.
+  private MessageOrBuilderExternalList<MType, BType, IType> externalMessageOrBuilderList;
+
+  /**
+   * Constructs a new builder with an empty list of messages.
+   *
+   * @param messages the current list of messages
+   * @param isMessagesListMutable Whether the messages list is mutable
+   * @param parent a listener to notify of changes
+   * @param isClean whether the builder is initially marked clean
+   */
+  public RepeatedFieldBuilderV3Internal(
+      List<MType> messages,
+      boolean isMessagesListMutable,
+      Message.BuilderParent parent,
+      boolean isClean) {
+    this.messages = messages;
+    this.isMessagesListMutable = isMessagesListMutable;
+    this.parent = parent;
+    this.isClean = isClean;
+  }
+
+  public void dispose() {
+    // Null out parent so we stop sending it invalidations.
+    parent = null;
+  }
+
+  /**
+   * Ensures that the list of messages is mutable so it can be updated. If it's immutable, a copy is
+   * made.
+   */
+  private void ensureMutableMessageList() {
+    if (!isMessagesListMutable) {
+      messages = new ArrayList<MType>(messages);
+      isMessagesListMutable = true;
+    }
+  }
+
+  /**
+   * Ensures that the list of builders is not null. If it's null, the list is created and
+   * initialized to be the same size as the messages list with null entries.
+   */
+  private void ensureBuilders() {
+    if (this.builders == null) {
+      this.builders = new ArrayList<SingleFieldBuilderV3Internal<MType, BType, IType>>(messages.size());
+      for (int i = 0; i < messages.size(); i++) {
+        builders.add(null);
+      }
+    }
+  }
+
+  /**
+   * Gets the count of items in the list.
+   *
+   * @return the count of items in the list.
+   */
+  public int getCount() {
+    return messages.size();
+  }
+
+  /**
+   * Gets whether the list is empty.
+   *
+   * @return whether the list is empty
+   */
+  public boolean isEmpty() {
+    return messages.isEmpty();
+  }
+
+  /**
+   * Get the message at the specified index. If the message is currently stored as a {@code
+   * Builder}, it is converted to a {@code Message} by calling {@link Message.Builder#buildPartial}
+   * on it.
+   *
+   * @param index the index of the message to get
+   * @return the message for the specified index
+   */
+  public MType getMessage(int index) {
+    return getMessage(index, false);
+  }
+
+  /**
+   * Get the message at the specified index. If the message is currently stored as a {@code
+   * Builder}, it is converted to a {@code Message} by calling {@link Message.Builder#buildPartial}
+   * on it.
+   *
+   * @param index the index of the message to get
+   * @param forBuild this is being called for build so we want to make sure we
+   *     SingleFieldBuilderV3.build to send dirty invalidations
+   * @return the message for the specified index
+   */
+  private MType getMessage(int index, boolean forBuild) {
+    if (this.builders == null) {
+      // We don't have any builders -- return the current Message.
+      // This is the case where no builder was created, so we MUST have a
+      // Message.
+      return messages.get(index);
+    }
+
+    SingleFieldBuilderV3Internal<MType, BType, IType> builder = builders.get(index);
+    if (builder == null) {
+      // We don't have a builder -- return the current message.
+      // This is the case where no builder was created for the entry at index,
+      // so we MUST have a message.
+      return messages.get(index);
+
+    } else {
+      return forBuild ? builder.build() : builder.getMessage();
+    }
+  }
+
+  /**
+   * Gets a builder for the specified index. If no builder has been created for that index, a
+   * builder is created on demand by calling {@link Message#toBuilder}.
+   *
+   * @param index the index of the message to get
+   * @return The builder for that index
+   */
+  public BType getBuilder(int index) {
+    ensureBuilders();
+    SingleFieldBuilderV3Internal<MType, BType, IType> builder = builders.get(index);
+    if (builder == null) {
+      MType message = messages.get(index);
+      builder = new SingleFieldBuilderV3Internal<MType, BType, IType>(message, this, isClean);
+      builders.set(index, builder);
+    }
+    return builder.getBuilder();
+  }
+
+  /**
+   * Gets the base class interface for the specified index. This may either be a builder or a
+   * message. It will return whatever is more efficient.
+   *
+   * @param index the index of the message to get
+   * @return the message or builder for the index as the base class interface
+   */
+  @SuppressWarnings("unchecked")
+  public IType getMessageOrBuilder(int index) {
+    if (this.builders == null) {
+      // We don't have any builders -- return the current Message.
+      // This is the case where no builder was created, so we MUST have a
+      // Message.
+      return (IType) messages.get(index);
+    }
+
+    SingleFieldBuilderV3Internal<MType, BType, IType> builder = builders.get(index);
+    if (builder == null) {
+      // We don't have a builder -- return the current message.
+      // This is the case where no builder was created for the entry at index,
+      // so we MUST have a message.
+      return (IType) messages.get(index);
+
+    } else {
+      return builder.getMessageOrBuilder();
+    }
+  }
+
+  static <T> T checkNotNull(T obj) {
+    if (obj == null) {
+      throw new NullPointerException();
+    }
+    return obj;
+  }
+
+  /**
+   * Sets a message at the specified index replacing the existing item at that index.
+   *
+   * @param index the index to set.
+   * @param message the message to set
+   * @return the builder
+   */
+//  @CanIgnoreReturnValue
+  public RepeatedFieldBuilderV3Internal<MType, BType, IType> setMessage(int index, MType message) {
+    checkNotNull(message);
+    ensureMutableMessageList();
+    messages.set(index, message);
+    if (builders != null) {
+      SingleFieldBuilderV3Internal<MType, BType, IType> entry = builders.set(index, null);
+      if (entry != null) {
+        entry.dispose();
+      }
+    }
+    onChanged();
+    incrementModCounts();
+    return this;
+  }
+
+  /**
+   * Appends the specified element to the end of this list.
+   *
+   * @param message the message to add
+   * @return the builder
+   */
+//  @CanIgnoreReturnValue
+  public RepeatedFieldBuilderV3Internal<MType, BType, IType> addMessage(MType message) {
+    checkNotNull(message);
+    ensureMutableMessageList();
+    messages.add(message);
+    if (builders != null) {
+      builders.add(null);
+    }
+    onChanged();
+    incrementModCounts();
+    return this;
+  }
+
+  /**
+   * Inserts the specified message at the specified position in this list. Shifts the element
+   * currently at that position (if any) and any subsequent elements to the right (adds one to their
+   * indices).
+   *
+   * @param index the index at which to insert the message
+   * @param message the message to add
+   * @return the builder
+   */
+//  @CanIgnoreReturnValue
+  public RepeatedFieldBuilderV3Internal<MType, BType, IType> addMessage(int index, MType message) {
+    checkNotNull(message);
+    ensureMutableMessageList();
+    messages.add(index, message);
+    if (builders != null) {
+      builders.add(index, null);
+    }
+    onChanged();
+    incrementModCounts();
+    return this;
+  }
+
+  /**
+   * Appends all of the messages in the specified collection to the end of this list, in the order
+   * that they are returned by the specified collection's iterator.
+   *
+   * @param values the messages to add
+   * @return the builder
+   */
+//  @CanIgnoreReturnValue
+  public RepeatedFieldBuilderV3Internal<MType, BType, IType> addAllMessages(
+      Iterable<? extends MType> values) {
+    for (final MType value : values) {
+      checkNotNull(value);
+    }
+
+    // If we can inspect the size, we can more efficiently add messages.
+    int size = -1;
+    if (values instanceof Collection) {
+      final Collection<?> collection = (Collection<?>) values;
+      if (collection.isEmpty()) {
+        return this;
+      }
+      size = collection.size();
+    }
+    ensureMutableMessageList();
+
+    if (size >= 0 && messages instanceof ArrayList) {
+      ((ArrayList<MType>) messages).ensureCapacity(messages.size() + size);
+    }
+
+    for (MType value : values) {
+      addMessage(value);
+    }
+
+    onChanged();
+    incrementModCounts();
+    return this;
+  }
+
+  /**
+   * Appends a new builder to the end of this list and returns the builder.
+   *
+   * @param message the message to add which is the basis of the builder
+   * @return the new builder
+   */
+  public BType addBuilder(MType message) {
+    ensureMutableMessageList();
+    ensureBuilders();
+    SingleFieldBuilderV3Internal<MType, BType, IType> builder =
+        new SingleFieldBuilderV3Internal<MType, BType, IType>(message, this, isClean);
+    messages.add(null);
+    builders.add(builder);
+    onChanged();
+    incrementModCounts();
+    return builder.getBuilder();
+  }
+
+  /**
+   * Inserts a new builder at the specified position in this list. Shifts the element currently at
+   * that position (if any) and any subsequent elements to the right (adds one to their indices).
+   *
+   * @param index the index at which to insert the builder
+   * @param message the message to add which is the basis of the builder
+   * @return the builder
+   */
+  public BType addBuilder(int index, MType message) {
+    ensureMutableMessageList();
+    ensureBuilders();
+    SingleFieldBuilderV3Internal<MType, BType, IType> builder =
+        new SingleFieldBuilderV3Internal<MType, BType, IType>(message, this, isClean);
+    messages.add(index, null);
+    builders.add(index, builder);
+    onChanged();
+    incrementModCounts();
+    return builder.getBuilder();
+  }
+
+  /**
+   * Removes the element at the specified position in this list. Shifts any subsequent elements to
+   * the left (subtracts one from their indices).
+   *
+   * @param index the index at which to remove the message
+   */
+  public void remove(int index) {
+    ensureMutableMessageList();
+    messages.remove(index);
+    if (builders != null) {
+      SingleFieldBuilderV3Internal<MType, BType, IType> entry = builders.remove(index);
+      if (entry != null) {
+        entry.dispose();
+      }
+    }
+    onChanged();
+    incrementModCounts();
+  }
+
+  /** Removes all of the elements from this list. The list will be empty after this call returns. */
+  public void clear() {
+    messages = Collections.emptyList();
+    isMessagesListMutable = false;
+    if (builders != null) {
+      for (SingleFieldBuilderV3Internal<MType, BType, IType> entry : builders) {
+        if (entry != null) {
+          entry.dispose();
+        }
+      }
+      builders = null;
+    }
+    onChanged();
+    incrementModCounts();
+  }
+
+  /**
+   * Builds the list of messages from the builder and returns them.
+   *
+   * @return an immutable list of messages
+   */
+  public List<MType> build() {
+    // Now that build has been called, we are required to dispatch
+    // invalidations.
+    isClean = true;
+
+    if (!isMessagesListMutable && builders == null) {
+      // We still have an immutable list and we never created a builder.
+      return messages;
+    }
+
+    boolean allMessagesInSync = true;
+    if (!isMessagesListMutable) {
+      // We still have an immutable list. Let's see if any of them are out
+      // of sync with their builders.
+      for (int i = 0; i < messages.size(); i++) {
+        Message message = messages.get(i);
+        SingleFieldBuilderV3Internal<MType, BType, IType> builder = builders.get(i);
+        if (builder != null) {
+          if (builder.build() != message) {
+            allMessagesInSync = false;
+            break;
+          }
+        }
+      }
+      if (allMessagesInSync) {
+        // Immutable list is still in sync.
+        return messages;
+      }
+    }
+
+    // Need to make sure messages is up to date
+    ensureMutableMessageList();
+    for (int i = 0; i < messages.size(); i++) {
+      messages.set(i, getMessage(i, true));
+    }
+
+    // We're going to return our list as immutable so we mark that we can
+    // no longer update it.
+    messages = Collections.unmodifiableList(messages);
+    isMessagesListMutable = false;
+    return messages;
+  }
+
+  /**
+   * Gets a view of the builder as a list of messages. The returned list is live and will reflect
+   * any changes to the underlying builder.
+   *
+   * @return the messages in the list
+   */
+  public List<MType> getMessageList() {
+    if (externalMessageList == null) {
+      externalMessageList = new MessageExternalList<MType, BType, IType>(this);
+    }
+    return externalMessageList;
+  }
+
+  /**
+   * Gets a view of the builder as a list of builders. This returned list is live and will reflect
+   * any changes to the underlying builder.
+   *
+   * @return the builders in the list
+   */
+  public List<BType> getBuilderList() {
+    if (externalBuilderList == null) {
+      externalBuilderList = new BuilderExternalList<MType, BType, IType>(this);
+    }
+    return externalBuilderList;
+  }
+
+  /**
+   * Gets a view of the builder as a list of MessageOrBuilders. This returned list is live and will
+   * reflect any changes to the underlying builder.
+   *
+   * @return the builders in the list
+   */
+  public List<IType> getMessageOrBuilderList() {
+    if (externalMessageOrBuilderList == null) {
+      externalMessageOrBuilderList = new MessageOrBuilderExternalList<MType, BType, IType>(this);
+    }
+    return externalMessageOrBuilderList;
+  }
+
+  /**
+   * Called when a the builder or one of its nested children has changed and any parent should be
+   * notified of its invalidation.
+   */
+  private void onChanged() {
+    if (isClean && parent != null) {
+      parent.markDirty();
+
+      // Don't keep dispatching invalidations until build is called again.
+      isClean = false;
+    }
+  }
+
+  @Override
+  public void markDirty() {
+    onChanged();
+  }
+
+  /**
+   * Increments the mod counts so that an ConcurrentModificationException can be thrown if calling
+   * code tries to modify the builder while its iterating the list.
+   */
+  private void incrementModCounts() {
+    if (externalMessageList != null) {
+      externalMessageList.incrementModCount();
+    }
+    if (externalBuilderList != null) {
+      externalBuilderList.incrementModCount();
+    }
+    if (externalMessageOrBuilderList != null) {
+      externalMessageOrBuilderList.incrementModCount();
+    }
+  }
+
+  /**
+   * Provides a live view of the builder as a list of messages.
+   *
+   * @param <MType> the type of message for the field
+   * @param <BType> the type of builder for the field
+   * @param <IType> the common interface for the message and the builder
+   */
+  private static class MessageExternalList<
+          MType extends Message,
+          BType extends Message.Builder,
+          IType extends MessageOrBuilder>
+      extends AbstractList<MType> implements List<MType>, RandomAccess {
+
+    RepeatedFieldBuilderV3Internal<MType, BType, IType> builder;
+
+    MessageExternalList(RepeatedFieldBuilderV3Internal<MType, BType, IType> builder) {
+      this.builder = builder;
+    }
+
+    @Override
+    public int size() {
+      return this.builder.getCount();
+    }
+
+    @Override
+    public MType get(int index) {
+      return builder.getMessage(index);
+    }
+
+    void incrementModCount() {
+      modCount++;
+    }
+  }
+
+  /**
+   * Provides a live view of the builder as a list of builders.
+   *
+   * @param <MType> the type of message for the field
+   * @param <BType> the type of builder for the field
+   * @param <IType> the common interface for the message and the builder
+   */
+  private static class BuilderExternalList<
+          MType extends Message,
+          BType extends Message.Builder,
+          IType extends MessageOrBuilder>
+      extends AbstractList<BType> implements List<BType>, RandomAccess {
+
+    RepeatedFieldBuilderV3Internal<MType, BType, IType> builder;
+
+    BuilderExternalList(RepeatedFieldBuilderV3Internal<MType, BType, IType> builder) {
+      this.builder = builder;
+    }
+
+    @Override
+    public int size() {
+      return this.builder.getCount();
+    }
+
+    @Override
+    public BType get(int index) {
+      return builder.getBuilder(index);
+    }
+
+    void incrementModCount() {
+      modCount++;
+    }
+  }
+
+  /**
+   * Provides a live view of the builder as a list of builders.
+   *
+   * @param <MType> the type of message for the field
+   * @param <BType> the type of builder for the field
+   * @param <IType> the common interface for the message and the builder
+   */
+  private static class MessageOrBuilderExternalList<
+          MType extends Message,
+          BType extends Message.Builder,
+          IType extends MessageOrBuilder>
+      extends AbstractList<IType> implements List<IType>, RandomAccess {
+
+    RepeatedFieldBuilderV3Internal<MType, BType, IType> builder;
+
+    MessageOrBuilderExternalList(RepeatedFieldBuilderV3Internal<MType, BType, IType> builder) {
+      this.builder = builder;
+    }
+
+    @Override
+    public int size() {
+      return this.builder.getCount();
+    }
+
+    @Override
+    public IType get(int index) {
+      return builder.getMessageOrBuilder(index);
+    }
+
+    void incrementModCount() {
+      modCount++;
+    }
+  }
+}

--- a/protobuf-sdk/src/main/java/com/google/protobuf/compiler/SingleFieldBuilderV3Internal.java
+++ b/protobuf-sdk/src/main/java/com/google/protobuf/compiler/SingleFieldBuilderV3Internal.java
@@ -1,0 +1,219 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+package com.google.protobuf.compiler;
+
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
+
+/**
+ * {@code SingleFieldBuilderV3} implements a structure that a protocol message uses to hold a single
+ * field of another protocol message. It supports the classical use case of setting an immutable
+ * {@link Message} as the value of the field and is highly optimized around this.
+ *
+ * <p>It also supports the additional use case of setting a {@link Message.Builder} as the field and
+ * deferring conversion of that {@code Builder} to an immutable {@code Message}. In this way, it's
+ * possible to maintain a tree of {@code Builder}'s that acts as a fully read/write data structure.
+ * <br>
+ * Logically, one can think of a tree of builders as converting the entire tree to messages when
+ * build is called on the root or when any method is called that desires a Message instead of a
+ * Builder. In terms of the implementation, the {@code SingleFieldBuilderV3} and {@code
+ * RepeatedFieldBuilderV3} classes cache messages that were created so that messages only need to be
+ * created when some change occurred in its builder or a builder for one of its descendants.
+ *
+ * @param <MType> the type of message for the field
+ * @param <BType> the type of builder for the field
+ * @param <IType> the common interface for the message and the builder
+ * @author jonp@google.com (Jon Perlow)
+ */
+class SingleFieldBuilderV3Internal<
+        MType extends Message,
+        BType extends Message.Builder,
+        IType extends MessageOrBuilder>
+    implements Message.BuilderParent {
+
+  // Parent to send changes to.
+  private Message.BuilderParent parent;
+
+  // Invariant: one of builder or message fields must be non-null.
+
+  // If set, this is the case where we are backed by a builder. In this case,
+  // message field represents a cached message for the builder (or null if
+  // there is no cached message).
+  private BType builder;
+
+  // If builder is non-null, this represents a cached message from the builder.
+  // If builder is null, this is the authoritative message for the field.
+  private MType message;
+
+  // Indicates that we've built a message and so we are now obligated
+  // to dispatch dirty invalidations. See AbstractMessage.BuilderListener.
+  private boolean isClean;
+
+  public SingleFieldBuilderV3Internal(MType message, Message.BuilderParent parent, boolean isClean) {
+    this.message = checkNotNull(message);
+    this.parent = parent;
+    this.isClean = isClean;
+  }
+
+  public void dispose() {
+    // Null out parent so we stop sending it invalidations.
+    parent = null;
+  }
+
+  /**
+   * Get the message for the field. If the message is currently stored as a {@code Builder}, it is
+   * converted to a {@code Message} by calling {@link Message.Builder#buildPartial} on it. If no
+   * message has been set, returns the default instance of the message.
+   *
+   * @return the message for the field
+   */
+  @SuppressWarnings("unchecked")
+  public MType getMessage() {
+    if (message == null) {
+      // If message is null, the invariant is that we must be have a builder.
+      message = (MType) builder.buildPartial();
+    }
+    return message;
+  }
+
+  /**
+   * Builds the message and returns it.
+   *
+   * @return the message
+   */
+  public MType build() {
+    // Now that build has been called, we are required to dispatch
+    // invalidations.
+    isClean = true;
+    return getMessage();
+  }
+
+  /**
+   * Gets a builder for the field. If no builder has been created yet, a builder is created on
+   * demand by calling {@link Message#toBuilder}.
+   *
+   * @return The builder for the field
+   */
+  @SuppressWarnings("unchecked")
+  public BType getBuilder() {
+    if (builder == null) {
+      // builder.mergeFrom() on a fresh builder
+      // does not create any sub-objects with independent clean/dirty states,
+      // therefore setting the builder itself to clean without actually calling
+      // build() cannot break any invariants.
+      builder = (BType) message.newBuilderForType();
+      builder.mergeFrom(message); // no-op if message is the default message
+//      builder.markClean();
+    }
+    return builder;
+  }
+
+  /**
+   * Gets the base class interface for the field. This may either be a builder or a message. It will
+   * return whatever is more efficient.
+   *
+   * @return the message or builder for the field as the base class interface
+   */
+  @SuppressWarnings("unchecked")
+  public IType getMessageOrBuilder() {
+    if (builder != null) {
+      return (IType) builder;
+    } else {
+      return (IType) message;
+    }
+  }
+
+  /**
+   * Sets a message for the field replacing any existing value.
+   *
+   * @param message the message to set
+   * @return the builder
+   */
+  // Comment out because CanIgnoreReturnValue is package private to com.google.protobuf
+//  @CanIgnoreReturnValue
+  public SingleFieldBuilderV3Internal<MType, BType, IType> setMessage(MType message) {
+    this.message = checkNotNull(message);
+    if (builder != null) {
+//      builder.dispose();
+      builder = null;
+    }
+    onChanged();
+    return this;
+  }
+
+  /**
+   * Merges the field from another field.
+   *
+   * @param value the value to merge from
+   * @return the builder
+   */
+//  @CanIgnoreReturnValue
+  public SingleFieldBuilderV3Internal<MType, BType, IType> mergeFrom(MType value) {
+    if (builder == null && message == message.getDefaultInstanceForType()) {
+      message = value;
+    } else {
+      getBuilder().mergeFrom(value);
+    }
+    onChanged();
+    return this;
+  }
+
+  /**
+   * Clears the value of the field.
+   *
+   * @return the builder
+   */
+  @SuppressWarnings("unchecked")
+//  @CanIgnoreReturnValue
+  public SingleFieldBuilderV3Internal<MType, BType, IType> clear() {
+    message =
+        (MType)
+            (message != null
+                ? message.getDefaultInstanceForType()
+                : builder.getDefaultInstanceForType());
+    if (builder != null) {
+//      builder.dispose();
+      builder = null;
+    }
+    onChanged();
+    // After clearing, parent is dirty, but this field builder is now clean and any changes should
+    // trickle up.
+    isClean = true;
+    return this;
+  }
+
+  /**
+   * Called when a the builder or one of its nested children has changed and any parent should be
+   * notified of its invalidation.
+   */
+  private void onChanged() {
+    // If builder is null, this is the case where onChanged is being called
+    // from setMessage or clear.
+    if (builder != null) {
+      message = null;
+    }
+    if (isClean && parent != null) {
+      parent.markDirty();
+
+      // Don't keep dispatching invalidations until build is called again.
+      isClean = false;
+    }
+  }
+
+  static <T> T checkNotNull(T obj) {
+    if (obj == null) {
+      throw new NullPointerException();
+    }
+    return obj;
+  }
+  
+  @Override
+  public void markDirty() {
+    onChanged();
+  }
+}


### PR DESCRIPTION
Introduce RepeatedFieldBuilderV3Internal and SingleFieldBuilderV3Internal for well-known types and PluginProtos. Move RepeatedFieldBuilderV3 and SingleFieldBuilderV3 to SDK package and restore the binary incompatibility, by change the constructor type from Message back to AbstractMessage.